### PR TITLE
feat: add custom dragstart event and improve drag enter/leave handling

### DIFF
--- a/src/lib/actions/draggable.ts
+++ b/src/lib/actions/draggable.ts
@@ -21,6 +21,10 @@ export function draggable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 
 		node.classList.add(...draggingClass);
 		options.callbacks?.onDragStart?.(dndState as DragDropState<T>);
+
+		// **Dispatch the custom event that bubbles up to the container**
+		const customEvent = new CustomEvent('dragstart-on-container', { bubbles: true });
+		node.dispatchEvent(customEvent);
 	}
 
 	function handleDragEnd() {


### PR DESCRIPTION
Similar issue to #2, the `drag-over` class doesn't always get removed properly.

For example, if you have two `droppable` containers *very* close to each other, dragging a `droppable` from one to the other causes both containers to get the class. This happens due to the speed/order the events are handled.

What I removed:
- The global state check ("this element equals target element") as it has proven unreliable

What I added:
- A simple counter for drag events on `droppable`
- A custom event from `draggable` to `droppable` (to remove the class from the source `droppable` since dragleave does not occur there)
