### PR TITLE
Support Vite 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
 		"svelte": "^5.0.0"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-cloudflare": "^4.8.0",
-		"@sveltejs/kit": "^2.11.0",
+		"@sveltejs/adapter-cloudflare": "^5.0.0",
+		"@sveltejs/kit": "^2.15.1",
 		"@sveltejs/package": "^2.3.7",
-		"@sveltejs/vite-plugin-svelte": "^4.0.3",
+		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@types/eslint": "^9.6.1",
 		"autoprefixer": "^10.4.20",
 		"eslint": "^9.16.0",
@@ -67,12 +67,12 @@
 		"prettier-plugin-svelte": "^3.3.2",
 		"prettier-plugin-tailwindcss": "^0.6.9",
 		"publint": "^0.2.12",
-		"svelte": "^5.11.2",
+		"svelte": "^5.16.1",
 		"svelte-check": "^4.1.1",
 		"tailwindcss": "^3.4.16",
 		"typescript": "^5.7.2",
 		"typescript-eslint": "^8.18.0",
-		"vite": "^5.4.11",
+		"vite": "^6.0.7",
 		"vitest": "^2.1.8"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
 		"@sveltejs/adapter-cloudflare": "^5.0.0",
 		"@sveltejs/kit": "^2.15.1",
 		"@sveltejs/package": "^2.3.7",
-		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@types/eslint": "^9.6.1",
 		"autoprefixer": "^10.4.20",
 		"eslint": "^9.16.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"import": "./dist/index.js",
+			"require": "./dist/index.js"
 		}
 	},
 	"peerDependencies": {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,12 +1,7 @@
 import adapter from '@sveltejs/adapter-cloudflare';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://svelte.dev/docs/kit/integrations
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
-
 	kit: {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.


### PR DESCRIPTION
*Apologies in advance, I was not able to find the exact version/change/package that led to this issue, nor could I find out exactly what the issue entails.*

When trying to upgrade to Vite 6 (and supported Svelte & SvelteKit versions), there are a couple compiler warnings. As well, any tests using Vitest + `@testing-library/svelte` fail to import this library:

```
Error: Failed to resolve entry for package "@thisux/sveltednd". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "@thisux/sveltednd" package
```

**I suspect this has something to do with Vite 6's new module resolution system.**

I was able to fix this by slightly modifying `package.json`. I also updated this package/site to Vite 6 + bumped the appropriate deps.