### PR TITLE
fix: bad enter/leave event order clearing drop target

### DIFF
--- a/src/lib/actions/droppable.ts
+++ b/src/lib/actions/droppable.ts
@@ -34,8 +34,10 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 
 		options.callbacks?.onDragLeave?.(dndState as DragDropState<T>);
 
-		dndState.targetContainer = null;
-		dndState.targetElement = null;
+		if (dndState.targetContainer === options.container && dndState.targetElement === event.target) {
+			dndState.targetContainer = null;
+			dndState.targetElement = null;
+		}
 	}
 
 	function handleDragOver(event: DragEvent) {
@@ -87,7 +89,9 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	function handlePointerOut(event: PointerEvent) {
 		if (options.disabled || !dndState.isDragging) return;
 
-		dndState.targetContainer = null;
+		if (dndState.targetContainer === options.container) {
+			dndState.targetContainer = null;
+		}
 		node.classList.remove(...dragOverClass);
 		options.callbacks?.onDragLeave?.(dndState as DragDropState<T>);
 	}


### PR DESCRIPTION
Sometimes, the `dragenter` event fires before the `dragleave` event, causing the drop target container and element information to be lost. While the exact cause isn't clear, this issue occurs fairly frequently when items are positioned very close to each other (e.g., with zero margin), at least on Firefox.

This pull request simply adds a check to ensure the drop target is only set to null if it hasn’t already been replaced by another item.