### PR TITLE
Fix drag-over class persistence after leaving drop zone

### DIFF
--- a/src/lib/actions/droppable.ts
+++ b/src/lib/actions/droppable.ts
@@ -37,6 +37,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		if (dndState.targetContainer === options.container && dndState.targetElement === event.target) {
 			dndState.targetContainer = null;
 			dndState.targetElement = null;
+			dragEnterCounter = 0; // Ensure dragEnterCounter is reset to 0
 		}
 	}
 


### PR DESCRIPTION
Fixes #22

Add a check to reset `dragEnterCounter` to 0 in `handleDragLeave` function in `src/lib/actions/droppable.ts`.

* Ensure `dragEnterCounter` is reset to 0 when the drag leaves the drop zone.
* Add a comment to indicate the purpose of resetting `dragEnterCounter`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thisuxhq/sveltednd/pull/23?shareId=acdf260d-1d2d-4fa3-8ef6-fcebb3aefaad).