### PR TITLE
fix: dragging on touch screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	],
 	"scripts": {
 		"dev": "vite dev",
+		"dev:host": "vite dev --host",
 		"build": "vite build && bun run package",
 		"preview": "vite preview",
 		"package": "svelte-kit sync && svelte-package && publint",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -120,7 +120,7 @@
 								animate:flip={{ duration: 200 }}
 								in:fade={{ duration: 150 }}
 								out:fade={{ duration: 150 }}
-								class="svelte-dnd-touch-feedback cursor-move rounded-lg bg-white p-3 shadow-sm ring-1
+								class="svelte-dnd-touch-feedback cursor-move select-none touch-none md:select-auto md:touch-auto rounded-lg bg-white p-3 shadow-sm ring-1
                                        ring-gray-200 transition-all duration-200 hover:shadow-md hover:ring-2 hover:ring-blue-200"
 							>
 								<div class="mb-2 flex items-start justify-between gap-2">

--- a/src/routes/conditional-check/+page.svelte
+++ b/src/routes/conditional-check/+page.svelte
@@ -79,7 +79,7 @@
 						{#each sourceFruits as fruit}
 							<div
 								use:draggable={{ container: 'source', dragData: fruit }}
-								class={`group flex items-center justify-between rounded-md border p-3 shadow-sm transition-all hover:shadow
+								class={`group flex items-center justify-between rounded-md border p-3 shadow-sm transition-all hover:shadow select-none touch-none md:select-auto md:touch-auto
 									${fruit.color === 'Red' ? 'border-red-200 bg-red-50/50' : 'border-muted bg-muted/5'}`}
 							>
 								<span class="font-medium">{fruit.name}</span>

--- a/src/routes/custom-classes/+page.svelte
+++ b/src/routes/custom-classes/+page.svelte
@@ -81,7 +81,7 @@
 						animate:flip={{ duration: 400, easing: 'cubic-bezier(0.4, 0, 0.2, 1)' }}
 						in:fade={{ duration: 300 }}
 						out:fade={{ duration: 200 }}
-						class="group relative cursor-move rounded-lg p-4
+						class="group relative cursor-move select-none touch-none md:select-auto md:touch-auto rounded-lg p-4
                                shadow-md ring-1 ring-white/60
                                backdrop-blur-md transition-all duration-500
                                ease-out hover:-rotate-1 hover:scale-[1.02]
@@ -93,7 +93,7 @@
 							<div
 								class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-white/20 opacity-0
                                       transition-all duration-500 group-hover:opacity-100"
-							/>
+							></div>
 
 							<!-- Kanban card content -->
 							<div class="relative z-10 space-y-2">

--- a/src/routes/grid-sort/+page.svelte
+++ b/src/routes/grid-sort/+page.svelte
@@ -46,7 +46,7 @@
 							container: index.toString(),
 							dragData: card
 						}}
-						class={`h-full w-full cursor-move rounded-lg bg-gradient-to-br ${card.color} svelte-dnd-touch-feedback shadow-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-xl active:scale-95 active:brightness-110`}
+						class={`h-full w-full cursor-move select-none touch-none md:select-auto md:touch-auto rounded-lg bg-gradient-to-br ${card.color} svelte-dnd-touch-feedback shadow-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-xl active:scale-95 active:brightness-110`}
 					>
 						<div class="flex h-full items-center justify-center">
 							<span class="text-4xl">{card.icon}</span>

--- a/src/routes/horizontal-scroll/+page.svelte
+++ b/src/routes/horizontal-scroll/+page.svelte
@@ -42,7 +42,7 @@
 					container: index.toString(),
 					callbacks: { onDrop: handleDrop }
 				}}
-				class="svelte-dnd-touch-feedback relative p-4"
+				class="svelte-dnd-touch-feedback relative p-4 select-none touch-none md:select-auto md:touch-auto"
 				animate:flip={{ duration: 200 }}
 				in:fade={{ duration: 150 }}
 				out:fade={{ duration: 150 }}

--- a/src/routes/interactive-elements/+page.svelte
+++ b/src/routes/interactive-elements/+page.svelte
@@ -57,7 +57,7 @@
 					dragData: item,
 					interactive: ['[data-delete-btn]', '[data-select-btn]', '.interactive']
 				}}
-				class="flex items-center justify-between rounded-lg bg-white p-4 shadow transition-all hover:shadow-md"
+				class="flex items-center select-none touch-none md:select-auto md:touch-auto justify-between rounded-lg bg-white p-4 shadow transition-all hover:shadow-md"
 			>
 				<button
 					data-select-btn

--- a/src/routes/multiple/+page.svelte
+++ b/src/routes/multiple/+page.svelte
@@ -106,7 +106,7 @@
 								animate:flip={{ duration: 200 }}
 								in:fade={{ duration: 150 }}
 								out:fade={{ duration: 150 }}
-								class="group cursor-move rounded-lg bg-white p-3 shadow-sm ring-1 ring-gray-200
+								class="group cursor-move select-none touch-none md:select-auto md:touch-auto rounded-lg bg-white p-3 shadow-sm ring-1 ring-gray-200
                                        transition-all duration-200 hover:shadow-md hover:ring-2 hover:ring-blue-200"
 							>
 								<div class="relative mb-2">

--- a/src/routes/nested/+page.svelte
+++ b/src/routes/nested/+page.svelte
@@ -130,7 +130,7 @@
 						container: groupIndex.toString(),
 						dragData: group
 					}}
-					class="svelte-dnd-touch-feedback rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-200"
+					class="svelte-dnd-touch-feedback select-none touch-none md:select-auto md:touch-auto rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-200"
 					in:fade={{ duration: 150 }}
 					out:fade={{ duration: 150 }}
 				>
@@ -161,7 +161,7 @@
 										container: `${group.id}:${itemIndex}`,
 										dragData: item
 									}}
-									class="svelte-dnd-touch-feedback cursor-move rounded-lg bg-white p-3 shadow-sm ring-1
+									class="svelte-dnd-touch-feedback cursor-move select-none touch-none rounded-lg bg-white p-3 shadow-sm ring-1
                                            ring-gray-200 transition-all duration-200 hover:shadow-md hover:ring-2 hover:ring-blue-200"
 								>
 									<div class="mb-2 flex items-start justify-between gap-2">

--- a/src/routes/simple-list/+page.svelte
+++ b/src/routes/simple-list/+page.svelte
@@ -70,7 +70,7 @@
 						animate:flip={{ duration: 200 }}
 						in:fade={{ duration: 150 }}
 						out:fade={{ duration: 150 }}
-						class="cursor-move rounded-lg bg-white p-3 shadow-sm ring-1 ring-gray-200
+						class="cursor-move select-none touch-none md:select-auto md:touch-auto rounded-lg bg-white p-3 shadow-sm ring-1 ring-gray-200
                                transition-all duration-200 hover:shadow-md hover:ring-2 hover:ring-blue-200 svelte-dnd-touch-feedback"
 					>
 						<div class="mb-2 flex items-start justify-between gap-2">


### PR DESCRIPTION
When using touch screen device, holding on draggable element will lead to selecting the element text instead of firing the pointer event. This Tailwind CSS utility should fix this issue. 

Also I added `dev:host` script to be able to test the fix on my phone