### PR TITLE
fix: Remove @thisux/sveltednd self-dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,5 @@
 		"typescript-eslint": "^8.18.0",
 		"vite": "^6.0.7",
 		"vitest": "^2.1.8"
-	},
-	"dependencies": {
-		"@thisux/sveltednd": "^0.0.18"
 	}
 }


### PR DESCRIPTION
# Remove Self-Dependency in `package.json`

- Removed `"@thisux/sveltednd"`from `"dependencies"` section in package.json.
- Avoids build issues.