### PR TITLE
docs: update stale architecture notes and fix npm→bun in CONTRIBUTING

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,15 @@ The library exports three things from `src/lib/index.ts`: two Svelte actions (`d
 
 1. `draggable` action attaches drag event listeners (both HTML5 and pointer events) to an element
 2. When dragging starts, it updates the global `dndState` (Svelte 5 `$state` rune in `src/lib/stores/dnd.svelte.ts`) and dispatches custom events
-3. `droppable` action listens for dragenter/dragleave/dragover/drop events and pointer events, updates `dndState.targetContainer`, and fires callbacks
-4. Application handles reordering in the `onDrop` callback
+3. On desktop, `pointercancel` fires when the browser takes over the pointer for HTML5 drag — an `html5DragActive` flag prevents this from resetting state mid-drag
+4. `droppable` action listens for dragenter/dragleave/dragover/drop events (HTML5 path) and a document-level `pointermove` + `getBoundingClientRect` (pointer/touch path), updates `dndState.targetContainer`, and fires callbacks
+5. On touch devices, `pointerover`/`pointerout` don't fire on elements beneath the finger, so hover detection uses coordinate-based bounds checking instead
+6. Application handles reordering in the `onDrop` callback
 
 **Key source files:**
 
 - `src/lib/actions/draggable.ts` - Drag action with handle support and interactive element blocking
-- `src/lib/actions/droppable.ts` - Drop action with nested element counter tracking (dragEnterCounter)
+- `src/lib/actions/droppable.ts` - Drop action with nested element counter tracking (dragEnterCounter) and coordinate-based touch hover detection (wasOver + getBoundingClientRect)
 - `src/lib/stores/dnd.svelte.ts` - Global reactive state (~11 lines)
 - `src/lib/types/index.ts` - All TypeScript interfaces (`DragDropState<T>`, `DraggableOptions<T>`, etc.)
 - `src/lib/styles/dnd.css` - Default CSS classes (`dragging`, `drag-over`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,13 @@ Thanks for wanting to contribute to **@thisux/sveltednd**! We’re happy to have
    ```bash
    git clone https://github.com/thisuxhq/sveltednd.git
    cd sveltednd
-   npm install
+   bun install
    ```
 
 2. Run these commands to check everything works:
-   - **`npm run dev`**: Starts the development server.
-   - **`npm run build`**: Builds the library.
-   - **`npm run test`**: Runs all tests.
+   - **`bun run dev`**: Starts the development server.
+   - **`bun run build`**: Builds the library.
+   - **`bun run test`**: Runs all tests.
 
 ## Code of Conduct
 
@@ -54,13 +54,13 @@ If you find a bug or want to suggest a new feature, [open an issue here](https:/
 - Run **Prettier** and **ESLint** to keep code clean:
 
   ```bash
-  npm run format
-  npm run lint
+  bun run format
+  bun run lint
   ```
 
 - **Use TypeScript** to catch errors:
   ```bash
-  npm run check
+  bun run check
   ```
 
 ## Testing
@@ -68,7 +68,7 @@ If you find a bug or want to suggest a new feature, [open an issue here](https:/
 Please write or update tests for any changes you make. To run tests:
 
 ```bash
-npm run test
+bun run test
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: Update architecture section to reflect touch/mobile fixes — document-level `pointermove` + `getBoundingClientRect` for hover detection, `html5DragActive` flag for `pointercancel` guarding, `wasOver` for touch transitions
- `CONTRIBUTING.md`: Replace all `npm run` commands with `bun run` (bun is the project's package manager)

No code changes.
🤖 Generated with [Claude Code](https://claude.com/claude-code)