### PR TITLE
chore: release v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@thisux/sveltednd",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"private": false,
 	"description": "A lightweight, flexible drag and drop library for Svelte 5 applications.",
 	"author": "sanju <work@sanju.sh>",

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -374,7 +374,7 @@ All generic types use `T = unknown` as default, so they work without specifying 
 ## Package Info
 
 - Package name: `@thisux/sveltednd`
-- Version: 0.1.1
+- Version: 0.1.2
 - License: MIT
 - Peer dependency: `svelte@^5.0.0`
 - Module type: ESM only (`"type": "module"`)


### PR DESCRIPTION
## v0.1.2

Patch release — mobile touch support and desktop multi-container fix.

### Bug Fixes

- **Mobile touch drag now works** (#33, #34) — replaced `pointerover`/`pointerout` hover detection in droppable with document-level `pointermove` + `getBoundingClientRect`. Touch devices don't fire `pointerover` on elements beneath the finger; coordinate-based detection works on all devices.
- **`pointercancel` resets stuck drag state on mobile** (#34) — when the browser cancels a touch gesture (scroll intent, palm rejection), `dndState.isDragging` is now correctly reset.
- **Multiple containers fixed on desktop** (#35, #36) — added `html5DragActive` flag to prevent `pointercancel` (fired by the browser when HTML5 drag takes over the pointer) from clearing `sourceContainer` mid-drag. Fixes drops silently doing nothing in multi-container layouts.

### Internal

- Dead handler functions (`handlePointerOver`, `handlePointerMove`, `handlePointerOut`) removed from droppable
- `wasOver` boolean tracks enter/leave transitions so `onDragEnter`/`onDragLeave` fire once per transition, not every frame
- `wasOver` reset in drag-end cleanup paths to prevent stale state across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)