### PR TITLE
docs: mention CI check requirement in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for wanting to contribute to **@thisux/sveltednd**! We’re happy to have you. Please follow these simple guidelines to make it easier for everyone.
 
+> **CI runs automatically** on every PR. All lint, type-check, and test checks must pass before merging.
+
 ---
 
 ## How to Get Started


### PR DESCRIPTION
Small addition to CONTRIBUTING.md noting that CI runs automatically on every PR. Tests the new CI pipeline.