### PR TITLE
[codex] Fix conditional drop validation cleanup

### DIFF
--- a/src/lib/actions/draggable.spec.ts
+++ b/src/lib/actions/draggable.spec.ts
@@ -12,6 +12,8 @@ describe('draggable', () => {
 		dndState.sourceContainer = '';
 		dndState.targetContainer = null;
 		dndState.targetElement = null;
+		dndState.dropPosition = null;
+		dndState.invalidDrop = false;
 		node = document.createElement('div');
 		document.body.appendChild(node);
 	});
@@ -356,6 +358,56 @@ describe('draggable', () => {
 	});
 
 	describe('General functionality', () => {
+		it('should reset stale validation state when a new drag starts', () => {
+			dndState.targetContainer = 'previous-target';
+			dndState.targetElement = document.createElement('div');
+			dndState.dropPosition = 'after';
+			dndState.invalidDrop = true;
+
+			const action = draggable(node, {
+				container: 'test',
+				dragData: 'test-data'
+			});
+
+			node.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }));
+
+			expect(dndState.isDragging).toBe(true);
+			expect(dndState.draggedItem).toBe('test-data');
+			expect(dndState.targetContainer).toBeNull();
+			expect(dndState.targetElement).toBeNull();
+			expect(dndState.dropPosition).toBeNull();
+			expect(dndState.invalidDrop).toBe(false);
+
+			action.destroy();
+		});
+
+		it('should clear validation state when a drag ends', () => {
+			const action = draggable(node, {
+				container: 'test',
+				attributes: { draggingClass: 'dragging' }
+			});
+
+			node.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }));
+
+			dndState.targetContainer = 'target';
+			dndState.targetElement = document.createElement('div');
+			dndState.dropPosition = 'before';
+			dndState.invalidDrop = true;
+
+			node.dispatchEvent(new DragEvent('dragend', { bubbles: true }));
+
+			expect(dndState.isDragging).toBe(false);
+			expect(dndState.draggedItem).toBeNull();
+			expect(dndState.sourceContainer).toBe('');
+			expect(dndState.targetContainer).toBeNull();
+			expect(dndState.targetElement).toBeNull();
+			expect(dndState.dropPosition).toBeNull();
+			expect(dndState.invalidDrop).toBe(false);
+			expect(node.classList.contains('dragging')).toBe(false);
+
+			action.destroy();
+		});
+
 		it('should NOT reset drag state when pointercancel fires during HTML5 drag (desktop)', () => {
 			const onDragEnd = vi.fn();
 			const action = draggable(node, {

--- a/src/lib/actions/draggable.ts
+++ b/src/lib/actions/draggable.ts
@@ -93,6 +93,47 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	let html5DragActive = false;
 
 	/**
+	 * Starts a new drag from a clean transient state.
+	 *
+	 * Conditional drop validation writes into dndState.invalidDrop. If a previous
+	 * drag was cancelled after hovering an invalid zone, that flag must not leak
+	 * into the next drag.
+	 */
+	function beginDragState() {
+		dndState.isDragging = true;
+		dndState.draggedItem = options.dragData;
+		dndState.sourceContainer = options.container;
+		dndState.targetContainer = null;
+		dndState.targetElement = null;
+		dndState.dropPosition = null;
+		dndState.invalidDrop = false;
+	}
+
+	/**
+	 * Removes document-level pointer listeners used by the custom pointer path.
+	 * HTML5 drags can cancel pointer events without delivering a matching pointerup,
+	 * so the HTML5 cleanup path also calls this.
+	 */
+	function removePointerListeners() {
+		document.removeEventListener('pointermove', handlePointerMove);
+		document.removeEventListener('pointerup', handlePointerUp);
+		document.removeEventListener('pointercancel', handlePointerCancel);
+	}
+
+	/**
+	 * Clears all transient drag state at the end of a drag.
+	 */
+	function endDragState() {
+		dndState.isDragging = false;
+		dndState.draggedItem = null;
+		dndState.sourceContainer = '';
+		dndState.targetContainer = null;
+		dndState.targetElement = null;
+		dndState.dropPosition = null;
+		dndState.invalidDrop = false;
+	}
+
+	/**
 	 * Checks if the clicked element (or its parent) is an interactive element.
 	 *
 	 * We walk up the DOM tree because the user might click on a span inside a button,
@@ -155,10 +196,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		html5DragActive = true;
 
 		// Update global state - this triggers reactive updates across all components
-		dndState.isDragging = true;
-		dndState.draggedItem = options.dragData;
-		dndState.sourceContainer = options.container;
-		dndState.targetContainer = null;
+		beginDragState();
 
 		// Configure the native drag data transfer
 		// We stringify the data so it works across different browser contexts
@@ -188,6 +226,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	 */
 	function handleDragEnd() {
 		html5DragActive = false;
+		removePointerListeners();
 
 		stopAutoScroll();
 
@@ -195,10 +234,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		options.callbacks?.onDragEnd?.(dndState as DragDropState<T>);
 
 		// Reset global state
-		dndState.isDragging = false;
-		dndState.draggedItem = null;
-		dndState.sourceContainer = '';
-		dndState.targetContainer = null;
+		endDragState();
 	}
 
 	/**
@@ -225,10 +261,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		if (!options.handle && isInteractiveElement(event.target as HTMLElement)) return;
 
 		// Initialize the drag state (same as HTML5 path)
-		dndState.isDragging = true;
-		dndState.draggedItem = options.dragData;
-		dndState.sourceContainer = options.container;
-		dndState.targetContainer = null;
+		beginDragState();
 
 		// Visual feedback
 		node.classList.add(...draggingClass);
@@ -277,12 +310,10 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	 * then dispatch a custom event that droppables listen for.
 	 */
 	function handlePointerUp(event: PointerEvent) {
-		if (!dndState.isDragging) return;
-
 		// Clean up our document listeners
-		document.removeEventListener('pointermove', handlePointerMove);
-		document.removeEventListener('pointerup', handlePointerUp);
-		document.removeEventListener('pointercancel', handlePointerCancel);
+		removePointerListeners();
+
+		if (!dndState.isDragging) return;
 
 		// Remove visual dragging styles
 		node.classList.remove(...draggingClass);
@@ -311,10 +342,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		// Consumer callback and state cleanup
 		options.callbacks?.onDragEnd?.(dndState as DragDropState<T>);
 
-		dndState.isDragging = false;
-		dndState.draggedItem = null;
-		dndState.sourceContainer = '';
-		dndState.targetContainer = null;
+		endDragState();
 	}
 
 	// === Setup: Attach all event listeners ===
@@ -373,9 +401,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 			node.removeEventListener('pointerdown', handlePointerDown);
 
 			// Safety cleanup: if component unmounts mid-drag, these might still be attached
-			document.removeEventListener('pointermove', handlePointerMove);
-			document.removeEventListener('pointerup', handlePointerUp);
-			document.removeEventListener('pointercancel', handlePointerCancel);
+			removePointerListeners();
 		}
 	};
 }

--- a/src/lib/actions/droppable.spec.ts
+++ b/src/lib/actions/droppable.spec.ts
@@ -12,6 +12,7 @@ describe('droppable', () => {
 		dndState.sourceContainer = '';
 		dndState.targetContainer = null;
 		dndState.targetElement = null;
+		dndState.dropPosition = null;
 		dndState.invalidDrop = false;
 		node = document.createElement('div');
 		document.body.appendChild(node);
@@ -140,6 +141,73 @@ describe('droppable', () => {
 			node.dispatchEvent(dropEvent);
 
 			expect(node.classList.contains('drag-over')).toBe(false);
+			action.destroy();
+		});
+	});
+
+	describe('Issue #53 - conditional validation cleanup', () => {
+		it('should replace drag-over class when reactive options change while hovered', () => {
+			const action = droppable(node, {
+				container: 'test',
+				attributes: { dragOverClass: 'valid-drop' }
+			});
+
+			node.dispatchEvent(new DragEvent('dragenter', { bubbles: true }));
+			expect(node.classList.contains('valid-drop')).toBe(true);
+
+			action.update({
+				container: 'test',
+				attributes: { dragOverClass: 'invalid-drop' }
+			});
+
+			expect(node.classList.contains('valid-drop')).toBe(false);
+			expect(node.classList.contains('invalid-drop')).toBe(true);
+
+			node.dispatchEvent(new DragEvent('dragleave', { bubbles: true }));
+			expect(node.classList.contains('invalid-drop')).toBe(false);
+
+			action.destroy();
+		});
+
+		it('should clear target state even when dragleave target differs from dragenter target', () => {
+			const child = document.createElement('span');
+			node.appendChild(child);
+			const action = droppable(node, { container: 'test' });
+
+			child.dispatchEvent(new DragEvent('dragenter', { bubbles: true }));
+			dndState.invalidDrop = true;
+
+			expect(dndState.targetContainer).toBe('test');
+			expect(dndState.targetElement).toBe(child);
+
+			node.dispatchEvent(new DragEvent('dragleave', { bubbles: true }));
+
+			expect(dndState.targetContainer).toBeNull();
+			expect(dndState.targetElement).toBeNull();
+			expect(dndState.invalidDrop).toBe(false);
+
+			action.destroy();
+		});
+
+		it('should clear stale target and validation state on global dragend', () => {
+			const action = droppable(node, {
+				container: 'test',
+				attributes: { dragOverClass: 'invalid-drop' }
+			});
+
+			node.dispatchEvent(new DragEvent('dragenter', { bubbles: true }));
+			dndState.invalidDrop = true;
+
+			expect(dndState.targetContainer).toBe('test');
+			expect(node.classList.contains('invalid-drop')).toBe(true);
+
+			document.dispatchEvent(new DragEvent('dragend', { bubbles: false }));
+
+			expect(dndState.targetContainer).toBeNull();
+			expect(dndState.targetElement).toBeNull();
+			expect(dndState.invalidDrop).toBe(false);
+			expect(node.classList.contains('invalid-drop')).toBe(false);
+
 			action.destroy();
 		});
 	});
@@ -613,17 +681,20 @@ describe('droppable', () => {
 			const onDragLeave = vi.fn();
 			const action = droppable(node, {
 				container: 'test',
+				attributes: { dragOverClass: 'drag-over' },
 				callbacks: { onDragLeave }
 			});
 
 			dndState.isDragging = true;
 			dndState.targetContainer = 'other-container'; // something else is active
 			dispatchDocumentPointerMove(60, 60); // enter this node
+			expect(node.classList.contains('drag-over')).toBe(true);
 			dndState.targetContainer = 'other-container'; // simulate another container taking over
 			dispatchDocumentPointerMove(5, 5); // leave this node bounds
 
 			// onDragLeave should not fire because targetContainer !== 'test'
 			expect(onDragLeave).not.toHaveBeenCalled();
+			expect(node.classList.contains('drag-over')).toBe(false);
 
 			action.destroy();
 		});

--- a/src/lib/actions/droppable.ts
+++ b/src/lib/actions/droppable.ts
@@ -57,7 +57,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	 * CSS classes to apply when an item is dragged over.
 	 * Supports multiple classes separated by spaces.
 	 */
-	const dragOverClass = (options.attributes?.dragOverClass || DEFAULT_DRAG_OVER_CLASS).split(' ');
+	let dragOverClass = getDragOverClass(options);
 
 	/**
 	 * Counter for tracking dragenter/dragleave events.
@@ -94,6 +94,38 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	 * pointermove tick. Used to fire onDragEnter/onDragLeave on transitions only.
 	 */
 	let wasOver = false;
+
+	/**
+	 * Reads the current drag-over class list from action options.
+	 *
+	 * The value can be reactive in Svelte templates, so it must be refreshed
+	 * when the action receives updated options.
+	 */
+	function getDragOverClass(currentOptions: DragDropOptions<T>) {
+		return (currentOptions.attributes?.dragOverClass || DEFAULT_DRAG_OVER_CLASS)
+			.split(' ')
+			.filter(Boolean);
+	}
+
+	function addDragOverClass() {
+		if (dragOverClass.length === 0) return;
+		node.classList.add(...dragOverClass);
+	}
+
+	function removeDragOverClass(classes = dragOverClass) {
+		if (classes.length === 0) return;
+		node.classList.remove(...classes);
+	}
+
+	/**
+	 * Clears this droppable's global target state when it owns the active target.
+	 */
+	function clearTargetState() {
+		if (dndState.targetContainer !== options.container) return;
+		dndState.targetContainer = null;
+		dndState.targetElement = null;
+		dndState.invalidDrop = false;
+	}
 
 	/**
 	 * Calculates whether the drop should be positioned before or after the target.
@@ -254,17 +286,20 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 
 		if (isOver) {
 			dndState.targetContainer = options.container;
-			node.classList.add(...dragOverClass);
+			dndState.targetElement = node;
+			addDragOverClass();
 			updateDropIndicator(event.clientY, event.clientX);
 			options.callbacks?.onDragOver?.(dndState as DragDropState<T>);
 			if (!wasOver) {
 				options.callbacks?.onDragEnter?.(dndState as DragDropState<T>);
 			}
-		} else if (wasOver && dndState.targetContainer === options.container) {
-			dndState.targetContainer = null;
-			node.classList.remove(...dragOverClass);
+		} else if (wasOver) {
+			removeDragOverClass();
 			clearDropIndicator();
-			options.callbacks?.onDragLeave?.(dndState as DragDropState<T>);
+			if (dndState.targetContainer === options.container) {
+				options.callbacks?.onDragLeave?.(dndState as DragDropState<T>);
+				clearTargetState();
+			}
 		}
 
 		wasOver = isOver;
@@ -285,7 +320,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		dndState.targetElement = event.target as HTMLElement;
 
 		// Visual feedback: highlight the drop zone
-		node.classList.add(...dragOverClass);
+		addDragOverClass();
 		options.callbacks?.onDragEnter?.(dndState as DragDropState<T>);
 	}
 
@@ -295,7 +330,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	 * Decrements the counter. Only when counter reaches 0 do we actually
 	 * consider this a "leave" (handles nested element bubbling).
 	 */
-	function handleDragLeave(event: DragEvent) {
+	function handleDragLeave(_event: DragEvent) {
 		if (options.disabled) return;
 
 		dragEnterCounter--;
@@ -307,15 +342,10 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		if (dragEnterCounter > 0) return;
 
 		// Actually leaving - remove visual feedback
-		node.classList.remove(...dragOverClass);
+		removeDragOverClass();
 		clearDropIndicator();
 		options.callbacks?.onDragLeave?.(dndState as DragDropState<T>);
-
-		// Clear target state if this was the active container
-		if (dndState.targetContainer === options.container && dndState.targetElement === event.target) {
-			dndState.targetContainer = null;
-			dndState.targetElement = null;
-		}
+		clearTargetState();
 	}
 
 	/**
@@ -356,7 +386,9 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 
 		// Reset counter - we're no longer dragging over this zone
 		dragEnterCounter = 0;
-		node.classList.remove(...dragOverClass);
+		removeDragOverClass();
+		dndState.targetContainer = options.container;
+		dndState.targetElement = event.target as HTMLElement;
 
 		try {
 			// Extract the dragged data from the HTML5 dataTransfer
@@ -370,6 +402,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		} finally {
 			// Always clean up the indicator, even if drop handler fails
 			clearDropIndicator();
+			clearTargetState();
 		}
 	}
 
@@ -387,13 +420,11 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		if (dragEnterCounter === 0) return;
 		if (node.contains(event.target as Node)) return;
 		dragEnterCounter = 0;
-		node.classList.remove(...dragOverClass);
+		wasOver = false;
+		removeDragOverClass();
 		clearDropIndicator();
-		if (dndState.targetContainer === options.container) {
-			dndState.targetContainer = null;
-			dndState.targetElement = null;
-		}
 		options.callbacks?.onDragLeave?.(dndState as DragDropState<T>);
+		clearTargetState();
 	}
 
 	/**
@@ -407,11 +438,14 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	 * started — triggers cleanup on this drop zone.
 	 */
 	function handleGlobalDragEnd() {
+		const hadActiveState =
+			dragEnterCounter > 0 || wasOver || dndState.targetContainer === options.container;
+
 		wasOver = false;
-		if (dragEnterCounter === 0) return;
 		dragEnterCounter = 0;
-		node.classList.remove(...dragOverClass);
+		removeDragOverClass();
 		clearDropIndicator();
+		if (hadActiveState) clearTargetState();
 	}
 
 	/**
@@ -423,8 +457,9 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	function handleDragStartOnContainer() {
 		if (options.disabled) return;
 		dragEnterCounter = 0;
-		node.classList.remove(...dragOverClass);
+		removeDragOverClass();
 		clearDropIndicator();
+		clearTargetState();
 		wasOver = false;
 	}
 
@@ -441,7 +476,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		if (dndState.targetContainer !== options.container) return;
 
 		dragEnterCounter = 0;
-		node.classList.remove(...dragOverClass);
+		removeDragOverClass();
 
 		try {
 			// Extract data from the custom event detail
@@ -454,6 +489,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 			console.error('Drop handling failed:', error);
 		} finally {
 			clearDropIndicator();
+			clearTargetState();
 		}
 	}
 
@@ -491,13 +527,22 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		 * @param newOptions - Updated configuration
 		 */
 		update(newOptions: DragDropOptions<T>) {
+			const previousDragOverClass = dragOverClass;
+			const hadActiveState =
+				dragEnterCounter > 0 || wasOver || dndState.targetContainer === options.container;
+
 			// Update exclusion if autoScroll option changed
 			if (newOptions.autoScroll === false && options.autoScroll !== false) {
 				addScrollExclusion(node);
 			} else if (newOptions.autoScroll !== false && options.autoScroll === false) {
 				removeScrollExclusion(node);
 			}
+
 			options = newOptions;
+			dragOverClass = getDragOverClass(options);
+
+			removeDragOverClass(previousDragOverClass);
+			if (hadActiveState) addDragOverClass();
 		},
 
 		/**
@@ -507,6 +552,8 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		 */
 		destroy() {
 			clearDropIndicator();
+			removeDragOverClass();
+			clearTargetState();
 			removeScrollExclusion(node);
 			node.removeEventListener('dragenter', handleDragEnter);
 			node.removeEventListener('dragleave', handleDragLeave);


### PR DESCRIPTION
## Summary
- Refresh droppable drag-over classes when reactive options change during hover.
- Clear stale target, targetElement, dropPosition, and invalidDrop state across leave, cancel, drop, and new-drag paths.
- Add regression tests for conditional validation cleanup.

## Root Cause
Conditional validation could leave stale global drag state after hovering a target and releasing outside of it. The droppable action also captured dragOverClass once, so reactive valid/invalid classes could get out of sync while hovered.

## Validation
- bun run test
- bun run lint
- bun run check (0 errors; existing unused-selector warnings)
- bun run build

Fixes #53