### PR TITLE
docs: THISUX community health pack

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,104 @@
+name: Bug report
+description: Report incorrect drag-and-drop behavior or a regression
+title: 'bug: '
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve **@thisux/sveltednd**.
+
+        For **security** issues, do not use this form — email
+        [hello@thisux.com](mailto:hello@thisux.com) per
+        [SECURITY.md](https://github.com/thisuxhq/sveltednd/blob/main/SECURITY.md).
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Where does the problem show up?
+      options:
+        - draggable action
+        - droppable action
+        - dndState / reactive state
+        - Touch / pointer events
+        - HTML5 drag path (desktop)
+        - Drop indicators / CSS classes
+        - Drag handles
+        - Nested containers
+        - Grid / horizontal layout
+        - Auto-scroll
+        - Types / TypeScript
+        - Demo site
+        - Docs
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Clear description of the bug.
+      placeholder: Dragging an item leaves the drag-over class stuck after leaving the zone…
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps or a small Svelte 5 snippet. Link a StackBlitz / repo if helpful.
+      placeholder: |
+        1. Open the nested containers demo
+        2. Drag item A into nested list B on mobile Safari
+        3. Observe …
+      render: markdown
+    validations:
+      required: true
+
+  - type: input
+    id: package-version
+    attributes:
+      label: '@thisux/sveltednd version'
+      placeholder: '0.4.1'
+    validations:
+      required: true
+
+  - type: input
+    id: svelte-version
+    attributes:
+      label: Svelte version
+      placeholder: '5.x'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Desktop (Chrome / Edge)
+        - Desktop (Firefox)
+        - Desktop (Safari)
+        - Mobile (iOS Safari)
+        - Mobile (Chrome Android)
+        - SSR / Node (N/A)
+        - Multiple / unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, console errors, browser versions, related issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/thisuxhq/sveltednd/blob/main/SECURITY.md
+    about: Please do not open public issues for security reports. Email hello@thisux.com instead.
+  - name: Documentation & examples
+    url: https://github.com/thisuxhq/sveltednd/blob/main/README.md
+    about: API reference and usage examples in the README and demo routes.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: Feature request
+description: Propose a new capability or improvement for sveltednd
+title: 'feat: '
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem you are solving and how you would use the feature
+        in a Svelte 5 app. Keep the API surface lean when possible.
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you building, and what is hard or impossible today?
+      placeholder: I need keyboard-accessible reordering for a sortable list in a design tool…
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or behavior
+      description: Sketch options, callbacks, or action attributes you have in mind.
+      placeholder: |
+        e.g. `use:draggable={{ ..., keyboard: true }}` with Arrow keys to move
+        and Space/Enter to pick up / drop.
+      render: markdown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - draggable / droppable actions
+        - dndState
+        - Accessibility / keyboard
+        - Touch / mobile
+        - Layouts (grid, horizontal, nested)
+        - Styling / indicators
+        - Types
+        - Docs / demos
+        - Tooling / packaging
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds, other libraries, or approaches you tried.
+
+  - type: checkboxes
+    id: willing
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a PR for this (with guidance if needed)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What does this PR change and why? Link related issues (e.g. Fixes #123). -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation only
+- [ ] Refactor / chore (no user-facing change)
+- [ ] Breaking change (note in summary; use `feat!` / `fix!` commit if needed)
+
+## Checklist
+
+- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] `bun run format` / `bun run lint` pass
+- [ ] `bun run check` passes (types / svelte-check)
+- [ ] `bun run test` passes
+- [ ] Tests added or updated for behavior changes (`*.spec.ts`)
+- [ ] Public API / README examples updated if the surface changed
+- [ ] Demo routes under `src/routes/` updated when relevant
+
+## Test plan
+
+<!-- How did you verify this? Unit tests, manual demo page, browser/device, etc. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Documentation
+
+- Align community health files with THISUX standards (SECURITY, CITATION,
+  issue/PR templates, license copyright, Code of Conduct contact)
+
 ## [0.4.1](https://github.com/thisuxhq/sveltednd/compare/sveltednd-v0.4.0...sveltednd-v0.4.1) (2026-04-23)
 
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "@thisux/sveltednd"
+abstract: "A lightweight, flexible drag and drop library for Svelte 5 applications. Built with TypeScript and Svelte's runes system."
+authors:
+  - name: "THISUX Private Limited"
+    website: "https://github.com/thisuxhq"
+license: MIT
+repository-code: "https://github.com/thisuxhq/sveltednd"
+url: "https://github.com/thisuxhq/sveltednd"
+date-released: "2026-04-23"
+version: "0.4.1"
+keywords:
+  - svelte
+  - svelte5
+  - drag-and-drop
+  - dnd
+  - typescript
+  - runes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -22,17 +22,17 @@ community include:
 - Giving and gracefully accepting constructive feedback
 - Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the
-  overall community
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or email
-  address, without their explicit permission
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
 - Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
@@ -60,7 +60,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-work@thisux.com.
+[hello@thisux.com](mailto:hello@thisux.com).
+
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -82,15 +83,15 @@ behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
 **Consequence**: A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
@@ -109,20 +110,24 @@ Violating these terms may lead to a permanent ban.
 standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla-coc].
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla-coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,82 +1,126 @@
 # Contributing to @thisux/sveltednd
 
-Thanks for wanting to contribute to **@thisux/sveltednd**! We’re happy to have you. Please follow these simple guidelines to make it easier for everyone.
+Thanks for contributing to **@thisux/sveltednd** — a lightweight drag and drop
+library for Svelte 5.
 
-> **CI runs automatically** on every PR. All lint, type-check, and test checks must pass before merging.
+By submitting a pull request or other contribution, you agree that your work is
+licensed under the same [MIT License](LICENSE) as the project, and copyright is
+held by **THISUX Private Limited** (or assigned as required for distribution).
+
+> **CI runs automatically** on every PR. Lint, type-check, and tests must pass
+> before merge.
+
+Please also follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ---
 
-## How to Get Started
+## Development setup
 
-1. **Fork** this repo and **clone** it to your computer:
+1. **Fork** the repo and **clone** your fork:
 
    ```bash
-   git clone https://github.com/thisuxhq/sveltednd.git
+   git clone https://github.com/<your-username>/sveltednd.git
    cd sveltednd
    bun install
    ```
 
-2. Run these commands to check everything works:
-   - **`bun run dev`**: Starts the development server.
-   - **`bun run build`**: Builds the library.
-   - **`bun run test`**: Runs all tests.
-
-## Code of Conduct
-
-Please be respectful and considerate to everyone. Follow the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/).
-
-## Reporting Issues
-
-If you find a bug or want to suggest a new feature, [open an issue here](https://github.com/thisuxhq/sveltednd/issues).
-
-- **Be specific** about what you need or found.
-- **Add details** like code snippets, screenshots, or steps to reproduce the issue.
-- **Check existing issues** to see if someone else already reported it.
-
-## Making a Pull Request
-
-1. **Create a new branch** for your work:
+2. Verify the toolchain:
 
    ```bash
-   git checkout -b feature/my-new-feature
+   bun run dev      # Demo app (SvelteKit)
+   bun run build    # Library build (vite + svelte-package)
+   bun run test     # Vitest unit tests
+   bun run check    # TypeScript / svelte-check
+   bun run lint     # Prettier + ESLint
    ```
 
-2. **Write clear commit messages** to describe your changes.
+Package manager: **Bun** is preferred (`bun install`, `bun run …`). npm works
+for install if needed.
 
-3. **Push your branch** and open a pull request:
+## Branching
 
-   ```bash
-   git push origin feature/my-new-feature
-   ```
-
-4. **Describe your changes** in the pull request, and mention if it fixes any issues.
-
-## Coding Style
-
-- Run **Prettier** and **ESLint** to keep code clean:
-
-  ```bash
-  bun run format
-  bun run lint
-  ```
-
-- **Use TypeScript** to catch errors:
-  ```bash
-  bun run check
-  ```
-
-## Testing
-
-Please write or update tests for any changes you make. To run tests:
+- Create a feature branch from `main` — do not commit directly to `main`.
+- Prefer descriptive names: `feat/keyboard-dnd`, `fix/touch-stuck-state`,
+  `docs/api-examples`.
 
 ```bash
-bun run test
+git checkout -b feat/my-change
 ```
+
+## Commit messages
+
+This repo enforces **[Conventional Commits](https://www.conventionalcommits.org/)**
+via Husky + commitlint. Non-conforming commits are rejected.
+
+Format: `type(scope): description`
+
+| Type       | When to use                                           |
+| ---------- | ----------------------------------------------------- |
+| `feat`     | New user-facing feature (triggers minor version bump) |
+| `fix`      | Bug fix (triggers patch bump)                         |
+| `docs`     | Documentation only                                    |
+| `chore`    | Tooling, deps, config                                 |
+| `refactor` | Code restructure, no behavior change                  |
+| `test`     | Adding or fixing tests                                |
+| `ci`       | CI/CD changes                                         |
+| `style`    | Formatting only                                       |
+
+Breaking changes: append `!` (e.g. `feat!: …`) or add a `BREAKING CHANGE:`
+footer.
+
+Examples:
+
+```
+feat: add keyboard drag support
+fix: prevent stuck drag state on mobile
+docs: update README with touch examples
+```
+
+## Pull requests
+
+1. Keep PRs focused — one concern per PR when practical.
+2. Update or add tests for behavior changes (`*.spec.ts` next to source under
+   `src/lib/`).
+3. Run before opening the PR:
+
+   ```bash
+   bun run format
+   bun run lint
+   bun run check
+   bun run test
+   ```
+
+4. Fill in the PR template: summary, type of change, and checklist.
+5. Link related issues (`Fixes #123`).
+
+### Project-specific rules
+
+- **TypeScript** strict mode; use `import type` for type-only imports.
+- Always include **`.js` extensions** in relative imports (NodeNext resolution).
+- Prefer `$lib` for internal imports: `import { x } from '$lib/actions/index.js'`.
+- Svelte actions: setup → handlers → `addEventListener` → return
+  `{ update(), destroy() }`.
+- State uses Svelte 5 **`$state` runes**, not legacy stores.
+- Formatting: **tabs**, single quotes in JS/TS, no trailing commas, 100 char
+  print width.
+- Do not add dependencies unless the change clearly needs them.
+
+## Reporting issues
+
+- Prefer the [issue templates](https://github.com/thisuxhq/sveltednd/issues/new/choose)
+  (bug report / feature request).
+- Search existing issues first.
+- For **security** findings, do **not** open a public issue — see
+  [SECURITY.md](SECURITY.md) and email `hello@thisux.com`.
 
 ## Documentation
 
-Help keep documentation clear and easy to understand. Update the README or add comments in code to explain any new features.
+- Keep the README API examples accurate when you change public APIs.
+- Demo routes under `src/routes/` are the living examples — update them when
+  behavior changes.
+- Changelog entries for releases are managed via release-please; no need to
+  hand-edit version numbers in PRs unless asked.
 
 ---
 
-Thanks for helping us make **@thisux/sveltednd** better!
+Thanks for helping improve **@thisux/sveltednd**.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 THISUX PRIVATE LIMITED
+Copyright (c) 2024-2026 THISUX Private Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 A lightweight, flexible drag and drop library for Svelte 5 applications. Built with TypeScript and Svelte's runes system for maximum performance and developer experience.
 
 [![npm version](https://badge.fury.io/js/@thisux%2Fsveltednd.svg)](https://www.npmjs.com/package/@thisux/sveltednd)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Copyright](https://img.shields.io/badge/©-THISUX%20Private%20Limited-111111.svg)](LICENSE)
+
+**Docs & community:** [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md) · [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## Features
 
@@ -461,12 +464,27 @@ The component just needs to spread its props onto a root element:
 
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
+coding style, Conventional Commits, and PR guidelines. Please also follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+Security vulnerabilities should be reported privately — see [SECURITY.md](SECURITY.md).
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## License
 
-MIT License — see [LICENSE](./LICENSE) for details.
+Copyright © 2024–2026 [THISUX Private Limited](https://github.com/thisuxhq).
+
+Released under the [MIT License](LICENSE). You may use, modify, and distribute
+this project for personal and commercial purposes, provided the copyright and
+permission notice are retained.
 
 ## Acknowledgment
 
-Created by [Sanju](https://sanju.sh), founder of [ThisUX Private Limited](https://thisux.com) — a design-led product studio. If you need help building your next product, [let's talk](https://cal.com/imsanju/15min).
+Created by [Sanju](https://sanju.sh), founder of
+[THISUX Private Limited](https://thisux.com) — a design-led product studio. If
+you need help building your next product,
+[let's talk](https://cal.com/imsanju/15min).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `main`  | :white_check_mark: |
+| Latest release (`0.4.x`) | :white_check_mark: |
+| Older releases | :x: Only critical fixes may be backported |
+
+We support the latest published release on npm and the `main` branch. Older
+versions may not receive security updates.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security-sensitive findings.**
+
+Report vulnerabilities privately by email:
+
+- **Email:** [hello@thisux.com](mailto:hello@thisux.com)
+- **Subject:** `[security] sveltednd`
+
+Include as much detail as you can:
+
+- Description of the issue and potential impact
+- Steps to reproduce (or a proof of concept)
+- Affected versions / commit SHAs if known
+- Suggested fix, if you have one
+
+## What to expect
+
+- We aim to acknowledge reports within **3 business days**
+- We will keep you updated as we investigate and prepare a fix
+- Please give us a reasonable window to release a patch before any public
+  disclosure
+
+Thank you for helping keep **@thisux/sveltednd** and its users safe.


### PR DESCRIPTION
## Summary

Applies the THISUX OSS / GitHub community health pack to **@thisux/sveltednd**.

- **LICENSE** — copyright `THISUX Private Limited` (2024–2026)
- **SECURITY.md** — private reports to `hello@thisux.com`
- **CITATION.cff** — org author, MIT, v0.4.1
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1; enforcement `hello@thisux.com`
- **CONTRIBUTING.md** — Bun setup, Conventional Commits, project rules, MIT contribution note
- **README.md** — badges, community links, explicit MIT / THISUX license blurb
- **CHANGELOG.md** — Keep a Changelog header + Unreleased hygiene note
- **Issue / PR templates** — Svelte DnD–specific bug & feature forms

GitHub About: description kept; topics added (`svelte`, `mit-license`, `drag-n-drop`).

No app/library code changes. No new release (tags already exist through `sveltednd-v0.4.1`).

## Test plan

- [ ] Review rendered LICENSE / SECURITY / CoC on GitHub after merge
- [ ] Confirm **New issue** shows bug + feature templates and security contact link
- [ ] Confirm PR template pre-fills on a test PR
- [ ] Spot-check README badges and footer license text