### PR TITLE
fix: drag lifecycle reliability (#61, #60, #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **#61** — Auto-scroll no longer jumps the page to the top on pointerdown /
+  first drag; scroll waits for a real pointer/drag position and pointer-path
+  starts auto-scroll on first `pointermove`
+- **#60** — Global `dndState` always resets after drop, including when `onDrop`
+  removes the dragged node (so `dragend` never fires); destroy mid-drag also
+  cleans up
+- **#27** — Nested droppables prefer the deepest target; HTML5 `drop` stops
+  propagation; nested demo supports group reorder + item move between groups
+
 ### Documentation
 
 - Align community health files with THISUX standards (SECURITY, CITATION,
   issue/PR templates, license copyright, Code of Conduct contact)
+- Nested containers demo rewritten with typed payloads and list-body drop zones
 
 ## [0.4.1](https://github.com/thisuxhq/sveltednd/compare/sveltednd-v0.4.0...sveltednd-v0.4.1) (2026-04-23)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,16 +1,16 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
+message: 'If you use this software, please cite it as below.'
 type: software
-title: "@thisux/sveltednd"
+title: '@thisux/sveltednd'
 abstract: "A lightweight, flexible drag and drop library for Svelte 5 applications. Built with TypeScript and Svelte's runes system."
 authors:
-  - name: "THISUX Private Limited"
-    website: "https://github.com/thisuxhq"
+  - name: 'THISUX Private Limited'
+    website: 'https://github.com/thisuxhq'
 license: MIT
-repository-code: "https://github.com/thisuxhq/sveltednd"
-url: "https://github.com/thisuxhq/sveltednd"
-date-released: "2026-04-23"
-version: "0.4.1"
+repository-code: 'https://github.com/thisuxhq/sveltednd'
+url: 'https://github.com/thisuxhq/sveltednd'
+date-released: '2026-04-23'
+version: '0.4.1'
 keywords:
   - svelte
   - svelte5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| `main`  | :white_check_mark: |
-| Latest release (`0.4.x`) | :white_check_mark: |
-| Older releases | :x: Only critical fixes may be backported |
+| Version                  | Supported                                 |
+| ------------------------ | ----------------------------------------- |
+| `main`                   | :white_check_mark:                        |
+| Latest release (`0.4.x`) | :white_check_mark:                        |
+| Older releases           | :x: Only critical fixes may be backported |
 
 We support the latest published release on npm and the `main` branch. Older
 versions may not receive security updates.

--- a/src/lib/actions/draggable.spec.ts
+++ b/src/lib/actions/draggable.spec.ts
@@ -515,5 +515,47 @@ describe('draggable', () => {
 			// Just verify destroy doesn't throw and removes listeners
 			expect(() => action.destroy()).not.toThrow();
 		});
+
+		it('should not start auto-scroll on pointerdown (issue #61)', async () => {
+			const { isAutoScrollActive } = await import('../utils/auto-scroll.js');
+			const action = draggable(node, {
+				container: 'test',
+				dragData: { id: '1' }
+			});
+
+			node.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }));
+			expect(dndState.isDragging).toBe(true);
+			expect(isAutoScrollActive()).toBe(false);
+
+			document.dispatchEvent(
+				new PointerEvent('pointermove', { bubbles: true, clientX: 50, clientY: 50 })
+			);
+			expect(isAutoScrollActive()).toBe(true);
+
+			document.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
+			expect(isAutoScrollActive()).toBe(false);
+
+			action.destroy();
+		});
+
+		it('should reset state when source node is destroyed mid-drag (issue #60)', () => {
+			const action = draggable(node, {
+				container: 'col-a',
+				dragData: { id: 'card-1' },
+				attributes: { draggingClass: 'dragging' }
+			});
+
+			node.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }));
+			expect(dndState.isDragging).toBe(true);
+			expect(node.classList.contains('dragging')).toBe(true);
+
+			// Simulate onDrop removing the node before dragend
+			action.destroy();
+			node.remove();
+
+			expect(dndState.isDragging).toBe(false);
+			expect(dndState.draggedItem).toBeNull();
+			expect(dndState.sourceContainer).toBe('');
+		});
 	});
 });

--- a/src/lib/actions/draggable.ts
+++ b/src/lib/actions/draggable.ts
@@ -28,7 +28,7 @@
  * @module draggable
  */
 
-import { dndState } from '$lib/stores/dnd.svelte.js';
+import { dndState, resetDndState } from '$lib/stores/dnd.svelte.js';
 import type { DraggableOptions, DragDropState } from '$lib/types/index.js';
 import { startAutoScroll, stopAutoScroll } from '$lib/utils/auto-scroll.js';
 
@@ -121,16 +121,21 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	}
 
 	/**
-	 * Clears all transient drag state at the end of a drag.
+	 * Full teardown after a drag ends (success or cancel).
+	 *
+	 * Idempotent so droppables can also call reset when the source node is
+	 * removed mid-drop and `dragend` never fires (#60).
 	 */
-	function endDragState() {
-		dndState.isDragging = false;
-		dndState.draggedItem = null;
-		dndState.sourceContainer = '';
-		dndState.targetContainer = null;
-		dndState.targetElement = null;
-		dndState.dropPosition = null;
-		dndState.invalidDrop = false;
+	function finishDrag() {
+		html5DragActive = false;
+		removePointerListeners();
+		stopAutoScroll();
+		node.classList.remove(...draggingClass);
+		// Best-effort: if this node was already removed, also clear any leftover class
+		document.querySelectorAll(`.${draggingClass[0]}`).forEach((el) => {
+			if (el instanceof HTMLElement) el.classList.remove(...draggingClass);
+		});
+		resetDndState();
 	}
 
 	/**
@@ -208,6 +213,8 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		// Visual feedback: add dragging class
 		node.classList.add(...draggingClass);
 
+		// Auto-scroll starts here for HTML5; the scroll loop waits for the first
+		// dragover coordinates so we never scroll toward (0,0) (#61).
 		startAutoScroll();
 
 		// Notify consumer via callback
@@ -222,19 +229,14 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	 * Handles HTML5 dragend event.
 	 *
 	 * Cleans up after the drag finishes - removes visual styles and resets state.
-	 * This fires whether the drop succeeded or was cancelled.
+	 * This fires whether the drop succeeded or was cancelled — unless the source
+	 * node was removed during onDrop, in which case droppable also resets (#60).
 	 */
 	function handleDragEnd() {
-		html5DragActive = false;
-		removePointerListeners();
-
-		stopAutoScroll();
-
-		node.classList.remove(...draggingClass);
-		options.callbacks?.onDragEnd?.(dndState as DragDropState<T>);
-
-		// Reset global state
-		endDragState();
+		// Snapshot state for onDragEnd before reset (consumers may inspect it)
+		const endState = { ...dndState } as DragDropState<T>;
+		options.callbacks?.onDragEnd?.(endState);
+		finishDrag();
 	}
 
 	/**
@@ -266,7 +268,9 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		// Visual feedback
 		node.classList.add(...draggingClass);
 
-		startAutoScroll();
+		// Do NOT start auto-scroll here. Starting on pointerdown with no real
+		// pointer coordinates caused the page to jump to the top (#61). Auto-scroll
+		// begins on the first pointermove instead (and still waits for coords).
 
 		// Notify consumer
 		options.callbacks?.onDragStart?.(dndState as DragDropState<T>);
@@ -280,12 +284,13 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	/**
 	 * Handles pointermove during a drag.
 	 *
-	 * Currently minimal - the heavy lifting (drop indicator positioning)
-	 * happens in the droppable's pointermove handler. We just validate
-	 * that we're still in a drag state.
+	 * Starts auto-scroll on the first move so hold-without-drag never scrolls
+	 * the page (#61). Drop indicator positioning lives on droppable handlers.
 	 */
 	function handlePointerMove(_event: PointerEvent) {
 		if (!dndState.isDragging) return;
+		// Safe to call repeatedly — startAutoScroll is idempotent.
+		startAutoScroll();
 	}
 
 	/**
@@ -310,15 +315,10 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	 * then dispatch a custom event that droppables listen for.
 	 */
 	function handlePointerUp(event: PointerEvent) {
-		// Clean up our document listeners
+		// Clean up our document listeners first so we don't re-enter
 		removePointerListeners();
 
 		if (!dndState.isDragging) return;
-
-		// Remove visual dragging styles
-		node.classList.remove(...draggingClass);
-
-		stopAutoScroll();
 
 		/**
 		 * Find what's actually under the cursor.
@@ -339,10 +339,10 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 			})
 		);
 
-		// Consumer callback and state cleanup
-		options.callbacks?.onDragEnd?.(dndState as DragDropState<T>);
-
-		endDragState();
+		// Snapshot for callback before reset
+		const endState = { ...dndState } as DragDropState<T>;
+		options.callbacks?.onDragEnd?.(endState);
+		finishDrag();
 	}
 
 	// === Setup: Attach all event listeners ===
@@ -400,8 +400,17 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 			node.removeEventListener('dragend', handleDragEnd);
 			node.removeEventListener('pointerdown', handlePointerDown);
 
-			// Safety cleanup: if component unmounts mid-drag, these might still be attached
-			removePointerListeners();
+			// If this node is destroyed mid-drag (common when onDrop reorders lists
+			// and the source element unmounts before dragend), force full cleanup (#60).
+			const wasSource =
+				dndState.isDragging &&
+				(dndState.draggedItem === options.dragData ||
+					node.classList.contains(draggingClass[0] ?? 'dragging'));
+			if (wasSource) {
+				finishDrag();
+			} else {
+				removePointerListeners();
+			}
 		}
 	};
 }

--- a/src/lib/actions/droppable.spec.ts
+++ b/src/lib/actions/droppable.spec.ts
@@ -338,7 +338,7 @@ describe('droppable', () => {
 			action.destroy();
 		});
 
-		it('should update dndState.draggedItem from event detail', async () => {
+		it('should pass draggedItem from event detail to onDrop and reset state (issue #60)', async () => {
 			const onDrop = vi.fn();
 			const dragData = { id: '123', name: 'Test Item' };
 
@@ -358,7 +358,10 @@ describe('droppable', () => {
 
 			await new Promise((resolve) => setTimeout(resolve, 0));
 
-			expect(dndState.draggedItem).toEqual(dragData);
+			expect(onDrop).toHaveBeenCalledWith(expect.objectContaining({ draggedItem: dragData }));
+			// Global state must be idle after drop so list mutations cannot stick (#60)
+			expect(dndState.isDragging).toBe(false);
+			expect(dndState.draggedItem).toBeNull();
 			action.destroy();
 		});
 
@@ -441,8 +444,11 @@ describe('droppable', () => {
 
 			await new Promise((resolve) => setTimeout(resolve, 0));
 
-			expect(dndState.draggedItem).toEqual(dragData);
+			expect(onDrop).toHaveBeenCalledWith(expect.objectContaining({ draggedItem: dragData }));
 			expect(mockDataTransfer.getData).toHaveBeenCalledWith('text/plain');
+			// State is reset after drop so apps never stick in isDragging (#60)
+			expect(dndState.isDragging).toBe(false);
+			expect(dndState.draggedItem).toBeNull();
 			action.destroy();
 		});
 
@@ -677,7 +683,7 @@ describe('droppable', () => {
 			action.destroy();
 		});
 
-		it('should not call onDragLeave when leaving a different container', () => {
+		it('should fire onDragLeave when pointer leaves even if another container was target', () => {
 			const onDragLeave = vi.fn();
 			const action = droppable(node, {
 				container: 'test',
@@ -686,17 +692,148 @@ describe('droppable', () => {
 			});
 
 			dndState.isDragging = true;
-			dndState.targetContainer = 'other-container'; // something else is active
 			dispatchDocumentPointerMove(60, 60); // enter this node
 			expect(node.classList.contains('drag-over')).toBe(true);
-			dndState.targetContainer = 'other-container'; // simulate another container taking over
+			// Simulate another container taking over target ownership
+			dndState.targetContainer = 'other-container';
 			dispatchDocumentPointerMove(5, 5); // leave this node bounds
 
-			// onDragLeave should not fire because targetContainer !== 'test'
-			expect(onDragLeave).not.toHaveBeenCalled();
+			expect(onDragLeave).toHaveBeenCalledTimes(1);
 			expect(node.classList.contains('drag-over')).toBe(false);
 
 			action.destroy();
+		});
+
+		it('should defer hover to a nested child droppable (issue #27)', () => {
+			const parent = node;
+			const child = document.createElement('div');
+			parent.appendChild(child);
+			// Mock layout: parent 0-200, child 20-80
+			vi.spyOn(parent, 'getBoundingClientRect').mockReturnValue({
+				top: 0,
+				left: 0,
+				right: 200,
+				bottom: 200,
+				width: 200,
+				height: 200,
+				x: 0,
+				y: 0,
+				toJSON: () => ({})
+			});
+			vi.spyOn(child, 'getBoundingClientRect').mockReturnValue({
+				top: 20,
+				left: 20,
+				right: 80,
+				bottom: 80,
+				width: 60,
+				height: 60,
+				x: 20,
+				y: 20,
+				toJSON: () => ({})
+			});
+			vi.spyOn(document, 'elementFromPoint').mockImplementation((x, y) => {
+				if (x >= 20 && x <= 80 && y >= 20 && y <= 80) return child;
+				if (x >= 0 && x <= 200 && y >= 0 && y <= 200) return parent;
+				return null;
+			});
+
+			const parentAction = droppable(parent, {
+				container: 'parent',
+				attributes: { dragOverClass: 'drag-over' }
+			});
+			const childAction = droppable(child, {
+				container: 'child',
+				attributes: { dragOverClass: 'drag-over' }
+			});
+
+			dndState.isDragging = true;
+			// Pointer over child — child owns, parent must not steal target
+			dispatchDocumentPointerMove(40, 40);
+			expect(dndState.targetContainer).toBe('child');
+			expect(child.classList.contains('drag-over')).toBe(true);
+			expect(parent.classList.contains('drag-over')).toBe(false);
+
+			// Pointer over parent chrome only
+			dispatchDocumentPointerMove(150, 150);
+			expect(dndState.targetContainer).toBe('parent');
+			expect(parent.classList.contains('drag-over')).toBe(true);
+
+			childAction.destroy();
+			parentAction.destroy();
+			child.remove();
+		});
+	});
+
+	describe('Issue #60 - reset after HTML5 drop', () => {
+		it('should reset isDragging after drop even when onDrop mutates state', async () => {
+			const onDrop = vi.fn(() => {
+				// Consumer removes source from list (simulated by leaving state dirty mid-callback)
+			});
+			const action = droppable(node, {
+				container: 'col-b',
+				callbacks: { onDrop }
+			});
+
+			dndState.isDragging = true;
+			dndState.draggedItem = { id: 'card-1' };
+			dndState.sourceContainer = 'col-a';
+			dndState.targetContainer = 'col-b';
+			node.classList.add('dragging');
+
+			const dataTransfer = {
+				getData: () => JSON.stringify({ id: 'card-1' }),
+				dropEffect: 'none' as DataTransfer['dropEffect']
+			};
+			const dropEvent = new DragEvent('drop', { bubbles: true, cancelable: true });
+			Object.defineProperty(dropEvent, 'dataTransfer', { value: dataTransfer });
+			node.dispatchEvent(dropEvent);
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(onDrop).toHaveBeenCalled();
+			expect(dndState.isDragging).toBe(false);
+			expect(dndState.draggedItem).toBeNull();
+			expect(dndState.sourceContainer).toBe('');
+			expect(dndState.targetContainer).toBeNull();
+
+			action.destroy();
+		});
+
+		it('should stopPropagation on drop so nested parents do not double-handle (issue #27)', async () => {
+			const parentOnDrop = vi.fn();
+			const childOnDrop = vi.fn();
+			const parent = node;
+			const child = document.createElement('div');
+			parent.appendChild(child);
+
+			const parentAction = droppable(parent, {
+				container: 'parent',
+				callbacks: { onDrop: parentOnDrop }
+			});
+			const childAction = droppable(child, {
+				container: 'child',
+				callbacks: { onDrop: childOnDrop }
+			});
+
+			dndState.isDragging = true;
+			dndState.targetContainer = 'child';
+
+			const dataTransfer = {
+				getData: () => JSON.stringify({ id: '1' }),
+				dropEffect: 'none' as DataTransfer['dropEffect']
+			};
+			const dropEvent = new DragEvent('drop', { bubbles: true, cancelable: true });
+			Object.defineProperty(dropEvent, 'dataTransfer', { value: dataTransfer });
+			child.dispatchEvent(dropEvent);
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(childOnDrop).toHaveBeenCalledTimes(1);
+			expect(parentOnDrop).not.toHaveBeenCalled();
+
+			childAction.destroy();
+			parentAction.destroy();
+			child.remove();
 		});
 	});
 

--- a/src/lib/actions/droppable.ts
+++ b/src/lib/actions/droppable.ts
@@ -34,9 +34,13 @@
  * @module droppable
  */
 
-import { dndState } from '$lib/stores/dnd.svelte.js';
+import { dndState, resetDndState } from '$lib/stores/dnd.svelte.js';
 import type { DragDropOptions, DragDropState } from '$lib/types/index.js';
-import { addScrollExclusion, removeScrollExclusion } from '$lib/utils/auto-scroll.js';
+import {
+	addScrollExclusion,
+	removeScrollExclusion,
+	stopAutoScroll
+} from '$lib/utils/auto-scroll.js';
 
 /**
  * Default CSS class applied when an item is dragged over this element.
@@ -278,13 +282,23 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		if (options.disabled || !dndState.isDragging) return;
 
 		const rect = node.getBoundingClientRect();
-		const isOver =
+		const boundsHit =
 			event.clientX >= rect.left &&
 			event.clientX <= rect.right &&
 			event.clientY >= rect.top &&
 			event.clientY <= rect.bottom;
 
-		if (isOver) {
+		// Nested droppables: prefer the deepest element under the pointer (#27).
+		// If a child droppable contains the point, do not steal targetContainer.
+		let ownsHover = false;
+		if (boundsHit) {
+			const under = document.elementFromPoint(event.clientX, event.clientY);
+			const deepestDroppable =
+				under instanceof Element ? under.closest('[data-sveltednd-droppable]') : null;
+			ownsHover = !deepestDroppable || deepestDroppable === node;
+		}
+
+		if (ownsHover) {
 			dndState.targetContainer = options.container;
 			dndState.targetElement = node;
 			addDragOverClass();
@@ -296,13 +310,13 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		} else if (wasOver) {
 			removeDragOverClass();
 			clearDropIndicator();
+			options.callbacks?.onDragLeave?.(dndState as DragDropState<T>);
 			if (dndState.targetContainer === options.container) {
-				options.callbacks?.onDragLeave?.(dndState as DragDropState<T>);
 				clearTargetState();
 			}
 		}
 
-		wasOver = isOver;
+		wasOver = ownsHover;
 	}
 
 	/**
@@ -314,6 +328,13 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	function handleDragEnter(event: DragEvent) {
 		if (options.disabled) return;
 		event.preventDefault();
+
+		// Nested: only the deepest droppable under the event target owns hover (#27)
+		const fromTarget =
+			event.target instanceof Element ? event.target.closest('[data-sveltednd-droppable]') : null;
+		if (fromTarget && fromTarget !== node) {
+			return;
+		}
 
 		dragEnterCounter++;
 		dndState.targetContainer = options.container;
@@ -330,8 +351,15 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	 * Decrements the counter. Only when counter reaches 0 do we actually
 	 * consider this a "leave" (handles nested element bubbling).
 	 */
-	function handleDragLeave(_event: DragEvent) {
+	function handleDragLeave(event: DragEvent) {
 		if (options.disabled) return;
+
+		// Nested: ignore leave events that belong to a deeper droppable (#27)
+		const fromTarget =
+			event.target instanceof Element ? event.target.closest('[data-sveltednd-droppable]') : null;
+		if (fromTarget && fromTarget !== node) {
+			return;
+		}
 
 		dragEnterCounter--;
 
@@ -362,12 +390,42 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		if (options.disabled) return;
 		event.preventDefault();
 
+		// Nested: defer to deeper droppable under the cursor (#27)
+		const fromTarget =
+			event.target instanceof Element ? event.target.closest('[data-sveltednd-droppable]') : null;
+		if (fromTarget && fromTarget !== node) {
+			return;
+		}
+
 		// Show the "move" cursor to indicate this is a valid drop target
 		if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+
+		dndState.targetContainer = options.container;
+		dndState.targetElement = node;
 
 		// Update the position indicator based on cursor position
 		updateDropIndicator(event.clientY, event.clientX);
 		options.callbacks?.onDragOver?.(dndState as DragDropState<T>);
+	}
+
+	/**
+	 * Ends the global drag session after a successful drop path.
+	 *
+	 * When onDrop mutates the list and removes the dragged element, the browser
+	 * often never fires `dragend` on that node. Without this reset, isDragging
+	 * stays true and indicators stick (#60). Idempotent with draggable cleanup.
+	 */
+	function finalizeDropSession() {
+		wasOver = false;
+		dragEnterCounter = 0;
+		removeDragOverClass();
+		clearDropIndicator();
+		stopAutoScroll();
+		// Best-effort remove leftover dragging classes (source may already be gone)
+		document.querySelectorAll('.dragging').forEach((el) => {
+			el.classList.remove('dragging');
+		});
+		resetDndState();
 	}
 
 	/**
@@ -376,13 +434,16 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	 * This is where the actual data update happens. We:
 	 * 1. Parse the dropped data from the dataTransfer
 	 * 2. Call the consumer's onDrop callback
-	 * 3. Clean up visual state
+	 * 3. Clean up visual + global drag state
 	 *
-	 * Supports async callbacks - state stays stable until the promise resolves.
+	 * Supports async callbacks - state is snapshotted for the callback, then
+	 * reset so a removed source node cannot leave the app stuck dragging.
 	 */
 	async function handleDrop(event: DragEvent) {
 		if (options.disabled) return;
 		event.preventDefault();
+		// Nested droppables: only the deepest zone that handles the drop should win (#27)
+		event.stopPropagation();
 
 		// Reset counter - we're no longer dragging over this zone
 		dragEnterCounter = 0;
@@ -390,19 +451,24 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		dndState.targetContainer = options.container;
 		dndState.targetElement = event.target as HTMLElement;
 
+		// Snapshot before consumer mutates DOM / before we reset
+		const dropState = { ...dndState } as DragDropState<T>;
+
 		try {
 			// Extract the dragged data from the HTML5 dataTransfer
 			if (event.dataTransfer) {
-				dndState.draggedItem = JSON.parse(event.dataTransfer.getData('text/plain')) as T;
+				const raw = event.dataTransfer.getData('text/plain');
+				if (raw) {
+					dropState.draggedItem = JSON.parse(raw) as T;
+					dndState.draggedItem = dropState.draggedItem;
+				}
 			}
 			// Let the consumer handle the actual data movement
-			await options.callbacks?.onDrop?.(dndState as DragDropState<T>);
+			await options.callbacks?.onDrop?.(dropState);
 		} catch (error) {
 			console.error('Drop handling failed:', error);
 		} finally {
-			// Always clean up the indicator, even if drop handler fails
-			clearDropIndicator();
-			clearTargetState();
+			finalizeDropSession();
 		}
 	}
 
@@ -470,30 +536,40 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 	 * when the pointer is released. We handle it the same way as HTML5 drop.
 	 *
 	 * Supports async callbacks - returns a Promise if the callback is async.
+	 * Global state is reset after onDrop so list mutations cannot stick (#60).
 	 */
 	async function handlePointerDropOnContainer(event: Event) {
 		if (options.disabled || !dndState.isDragging) return;
 		if (dndState.targetContainer !== options.container) return;
 
+		// Nested: only the matching target handles the drop; stop further bubbling (#27)
+		event.stopPropagation();
+
 		dragEnterCounter = 0;
 		removeDragOverClass();
+
+		const dropState = { ...dndState } as DragDropState<T>;
 
 		try {
 			// Extract data from the custom event detail
 			const customEvent = event as CustomEvent;
 			if (customEvent.detail?.dragData) {
+				dropState.draggedItem = customEvent.detail.dragData;
 				dndState.draggedItem = customEvent.detail.dragData;
 			}
-			await options.callbacks?.onDrop?.(dndState as DragDropState<T>);
+			await options.callbacks?.onDrop?.(dropState);
 		} catch (error) {
 			console.error('Drop handling failed:', error);
 		} finally {
-			clearDropIndicator();
-			clearTargetState();
+			// Pointer path also ends via draggable.finishDrag; keep this idempotent.
+			finalizeDropSession();
 		}
 	}
 
 	// === Setup: Attach all event listeners ===
+
+	// Marker for nested deepest-target resolution (#27)
+	node.setAttribute('data-sveltednd-droppable', options.container);
 
 	// HTML5 drag API events
 	node.addEventListener('dragenter', handleDragEnter);
@@ -540,6 +616,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 
 			options = newOptions;
 			dragOverClass = getDragOverClass(options);
+			node.setAttribute('data-sveltednd-droppable', options.container);
 
 			removeDragOverClass(previousDragOverClass);
 			if (hadActiveState) addDragOverClass();
@@ -555,6 +632,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 			removeDragOverClass();
 			clearTargetState();
 			removeScrollExclusion(node);
+			node.removeAttribute('data-sveltednd-droppable');
 			node.removeEventListener('dragenter', handleDragEnter);
 			node.removeEventListener('dragleave', handleDragLeave);
 			node.removeEventListener('dragover', handleDragOver);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -38,7 +38,7 @@ export { draggable, droppable } from './actions/index.js';
 // === Store ===
 // Global reactive state tracking the current drag operation.
 // Access this for real-time drag info in your components.
-export { dndState } from './stores/dnd.svelte.js';
+export { dndState, resetDndState } from './stores/dnd.svelte.js';
 
 // === Types ===
 // Full TypeScript type definitions for options, callbacks, and state.

--- a/src/lib/stores/dnd.svelte.ts
+++ b/src/lib/stores/dnd.svelte.ts
@@ -57,3 +57,20 @@ export const dndState = $state<DragDropState>({
 	 */
 	invalidDrop: false
 });
+
+/**
+ * Resets all transient drag state to idle.
+ *
+ * Idempotent — safe to call from multiple end paths (drop, dragend, pointerup,
+ * destroy). Critical when `onDrop` removes the dragged node from the DOM:
+ * the browser may never fire `dragend`, so droppables must also reset (#60).
+ */
+export function resetDndState(): void {
+	dndState.isDragging = false;
+	dndState.draggedItem = null;
+	dndState.sourceContainer = '';
+	dndState.targetContainer = null;
+	dndState.targetElement = null;
+	dndState.dropPosition = null;
+	dndState.invalidDrop = false;
+}

--- a/src/lib/utils/auto-scroll.spec.ts
+++ b/src/lib/utils/auto-scroll.spec.ts
@@ -69,6 +69,43 @@ describe('auto-scroll manager', () => {
 
 			stopAutoScroll();
 		});
+
+		it('should not have a pointer position until the first move (issue #61)', () => {
+			startAutoScroll();
+			expect(_testing.hasPointerPosition).toBe(false);
+
+			document.dispatchEvent(
+				new PointerEvent('pointermove', { clientX: 120, clientY: 240, bubbles: true })
+			);
+			expect(_testing.hasPointerPosition).toBe(true);
+			expect(_testing.lastClientX).toBe(120);
+			expect(_testing.lastClientY).toBe(240);
+
+			stopAutoScroll();
+			expect(_testing.hasPointerPosition).toBe(false);
+		});
+
+		it('should not scroll the viewport before a real pointer position is known (issue #61)', () => {
+			const scrollBy = vi.spyOn(window, 'scrollBy').mockImplementation(() => {});
+			// Drive rAF callbacks manually
+			const callbacks: FrameRequestCallback[] = [];
+			vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+				callbacks.push(cb);
+				return callbacks.length;
+			});
+
+			startAutoScroll();
+			// First scheduled frame — no position yet, must not scroll
+			callbacks[0]?.(0);
+			expect(scrollBy).not.toHaveBeenCalled();
+
+			_testing.setPointerPosition(10, 10);
+			callbacks[1]?.(0);
+			// Near top edge with a real position — may scroll
+			expect(scrollBy).toHaveBeenCalled();
+
+			stopAutoScroll();
+		});
 	});
 
 	describe('calcScrollSpeed', () => {

--- a/src/lib/utils/auto-scroll.ts
+++ b/src/lib/utils/auto-scroll.ts
@@ -5,6 +5,10 @@
  * listeners, and runs a requestAnimationFrame loop that scrolls any
  * scrollable ancestor whose edge the pointer is near.
  *
+ * IMPORTANT: The scroll loop must not run until a real pointer/drag
+ * position has been observed. Starting with default (0,0) scrolls the
+ * page toward the top-left on first pointerdown (issue #61).
+ *
  * @module auto-scroll
  */
 
@@ -14,6 +18,12 @@ const MAX_SCROLL_SPEED = 15;
 /** Pointer position cached from the most recent move event. */
 let lastClientX = 0;
 let lastClientY = 0;
+
+/**
+ * True after at least one pointermove or dragover during the session.
+ * Until then, the rAF loop must not scroll (avoids jump-to-top on #61).
+ */
+let hasPointerPosition = false;
 
 /** rAF handle for the scroll loop. */
 let rafHandle: number | null = null;
@@ -138,16 +148,19 @@ function scrollViewport(): void {
 function scrollLoop(): void {
 	if (!active) return;
 
-	const elementUnderPointer = document.elementFromPoint(lastClientX, lastClientY);
-	if (elementUnderPointer) {
-		const ancestors = getScrollableAncestors(elementUnderPointer as HTMLElement);
-		for (const container of ancestors) {
-			scrollContainer(container);
+	// Wait for a real pointer/drag position so we never scroll toward (0,0)
+	if (hasPointerPosition) {
+		const elementUnderPointer = document.elementFromPoint(lastClientX, lastClientY);
+		if (elementUnderPointer) {
+			const ancestors = getScrollableAncestors(elementUnderPointer as HTMLElement);
+			for (const container of ancestors) {
+				scrollContainer(container);
+			}
 		}
-	}
 
-	// Always check viewport
-	scrollViewport();
+		// Always check viewport
+		scrollViewport();
+	}
 
 	rafHandle = requestAnimationFrame(scrollLoop);
 }
@@ -156,21 +169,29 @@ function scrollLoop(): void {
 function handlePointerMove(event: PointerEvent): void {
 	lastClientX = event.clientX;
 	lastClientY = event.clientY;
+	hasPointerPosition = true;
 }
 
 /** Caches pointer position from dragover events (HTML5 path). */
 function handleDragOver(event: DragEvent): void {
 	lastClientX = event.clientX;
 	lastClientY = event.clientY;
+	hasPointerPosition = true;
 }
 
 /**
  * Starts the auto-scroll manager.
- * Call when a drag operation begins.
+ * Call when a drag operation begins (or on first pointermove after drag start).
+ *
+ * Scrolling itself only begins after the first pointermove/dragover updates
+ * the cached coordinates (#61).
  */
 export function startAutoScroll(): void {
 	if (active) return;
 	active = true;
+	hasPointerPosition = false;
+	lastClientX = 0;
+	lastClientY = 0;
 
 	document.addEventListener('pointermove', handlePointerMove, { passive: true });
 	document.addEventListener('dragover', handleDragOver, { passive: true });
@@ -185,6 +206,7 @@ export function startAutoScroll(): void {
 export function stopAutoScroll(): void {
 	if (!active) return;
 	active = false;
+	hasPointerPosition = false;
 
 	document.removeEventListener('pointermove', handlePointerMove);
 	document.removeEventListener('dragover', handleDragOver);
@@ -196,6 +218,11 @@ export function stopAutoScroll(): void {
 
 	// Clear cache for next drag session
 	scrollableCache = new WeakMap<HTMLElement, boolean>();
+}
+
+/** Whether auto-scroll is currently active (for tests). */
+export function isAutoScrollActive(): boolean {
+	return active;
 }
 
 /** Add an element to the exclusion set (autoScroll: false). */
@@ -214,5 +241,20 @@ export const _testing = {
 	isScrollable,
 	getScrollableAncestors,
 	addExclusion: addScrollExclusion,
-	removeExclusion: removeScrollExclusion
+	removeExclusion: removeScrollExclusion,
+	get hasPointerPosition() {
+		return hasPointerPosition;
+	},
+	get lastClientY() {
+		return lastClientY;
+	},
+	get lastClientX() {
+		return lastClientX;
+	},
+	/** Simulate a pointer position without going through DOM events. */
+	setPointerPosition(x: number, y: number) {
+		lastClientX = x;
+		lastClientY = y;
+		hasPointerPosition = true;
+	}
 };

--- a/src/routes/nested/+page.svelte
+++ b/src/routes/nested/+page.svelte
@@ -18,12 +18,9 @@
 		items: Item[];
 	}
 
-	interface DraggedItem {
-		id: string;
-		title: string;
-		description: string;
-		priority: 'low' | 'medium' | 'high';
-	}
+	type NestedDragPayload =
+		| { kind: 'group'; group: Group }
+		| { kind: 'item'; item: Item; groupId: string };
 
 	let groups = $state<Group[]>([
 		{
@@ -66,35 +63,72 @@
 		}
 	]);
 
-	function handleGroupDrop(state: DragDropState<DraggedItem>) {
-		const { draggedItem, sourceContainer, targetContainer } = state;
-		if (!targetContainer || sourceContainer === targetContainer) return;
+	/** Reorder groups when a group is dropped onto another group shell. */
+	function handleGroupDrop(state: DragDropState<NestedDragPayload>) {
+		const { draggedItem, targetContainer } = state;
+		if (!draggedItem || draggedItem.kind !== 'group' || !targetContainer) return;
 
-		const sourceIndex = groups.findIndex((g) => g.id === draggedItem.id);
-		const targetIndex = parseInt(targetContainer);
+		const sourceIndex = groups.findIndex((g) => g.id === draggedItem.group.id);
+		const targetIndex = groups.findIndex((g) => g.id === targetContainer);
+		if (sourceIndex === -1 || targetIndex === -1 || sourceIndex === targetIndex) return;
 
-		const [movedGroup] = groups.splice(sourceIndex, 1);
-		groups = [...groups.slice(0, targetIndex), movedGroup, ...groups.slice(targetIndex)];
+		const next = [...groups];
+		const [moved] = next.splice(sourceIndex, 1);
+		next.splice(targetIndex, 0, moved);
+		groups = next;
 	}
 
-	function handleItemDrop(groupId: string, state: DragDropState<DraggedItem>) {
-		const { draggedItem, sourceContainer, targetContainer } = state;
-		if (!targetContainer || !draggedItem) return;
+	/**
+	 * Move or reorder items within / across groups.
+	 * Item drop targets use container ids: `item:{groupId}:{itemId}` or `list:{groupId}`.
+	 */
+	function handleItemDrop(state: DragDropState<NestedDragPayload>) {
+		const { draggedItem, targetContainer, dropPosition } = state;
+		if (!draggedItem || draggedItem.kind !== 'item' || !targetContainer) return;
 
-		const [sourceGroupId] = sourceContainer.split(':');
-		const [targetGroupId, targetIndexStr] = targetContainer.split(':');
-		const targetIndex = parseInt(targetIndexStr);
+		const item = draggedItem.item;
+		const sourceGroupId = draggedItem.groupId;
+
+		let targetGroupId: string;
+		let targetIndex: number;
+
+		if (targetContainer.startsWith('list:')) {
+			// Dropped on empty list body — append to that group
+			targetGroupId = targetContainer.slice('list:'.length);
+			const targetGroup = groups.find((g) => g.id === targetGroupId);
+			if (!targetGroup) return;
+			targetIndex = targetGroup.items.length;
+		} else if (targetContainer.startsWith('item:')) {
+			// item:{groupId}:{itemId}
+			const parts = targetContainer.split(':');
+			targetGroupId = parts[1] ?? '';
+			const targetItemId = parts[2] ?? '';
+			const targetGroup = groups.find((g) => g.id === targetGroupId);
+			if (!targetGroup) return;
+			const idx = targetGroup.items.findIndex((i) => i.id === targetItemId);
+			if (idx === -1) return;
+			targetIndex = dropPosition === 'after' ? idx + 1 : idx;
+		} else {
+			return;
+		}
 
 		const sourceGroup = groups.find((g) => g.id === sourceGroupId);
 		const targetGroup = groups.find((g) => g.id === targetGroupId);
-
 		if (!sourceGroup || !targetGroup) return;
 
-		sourceGroup.items = sourceGroup.items.filter((item: DraggedItem) => item.id !== draggedItem.id);
+		// Remove from source
+		const fromIndex = sourceGroup.items.findIndex((i) => i.id === item.id);
+		if (fromIndex === -1) return;
+		sourceGroup.items = sourceGroup.items.filter((i) => i.id !== item.id);
+
+		// Adjust target index when moving within the same group after the original index
+		if (sourceGroupId === targetGroupId && fromIndex < targetIndex) {
+			targetIndex -= 1;
+		}
 
 		targetGroup.items = [
 			...targetGroup.items.slice(0, targetIndex),
-			draggedItem,
+			item,
 			...targetGroup.items.slice(targetIndex)
 		];
 
@@ -135,38 +169,50 @@
 	<header class="border-b border-swiss-black px-8 py-12 dark:border-white/20 md:px-16 md:py-16">
 		<h1 class="text-3xl text-swiss-black dark:text-white md:text-4xl">nested containers</h1>
 		<p class="mt-4 max-w-xl text-sm text-swiss-mid-gray dark:text-white/60">
-			drag items within groups and between different groups
+			drag groups to reorder them · drag items within a group or between groups
 		</p>
 	</header>
 
 	<!-- Content -->
 	<div class="p-8 md:p-16">
 		<div class="grid gap-8 md:grid-cols-2">
-			{#each groups as group, groupIndex (group.id)}
+			{#each groups as group (group.id)}
+				<!-- Group shell: accepts other groups for reordering -->
 				<div
 					use:droppable={{
-						container: groupIndex.toString(),
+						container: group.id,
 						callbacks: { onDrop: handleGroupDrop }
 					}}
 					animate:flip={{ duration: 200 }}
 				>
 					<div
-						use:draggable={{
-							container: groupIndex.toString(),
-							dragData: group
-						}}
 						class="svelte-dnd-touch-feedback border border-swiss-black bg-white dark:border-white/20 dark:bg-swiss-black"
 						in:fade={{ duration: 150 }}
 						out:fade={{ duration: 150 }}
 					>
-						<!-- Group Header -->
-						<div class="border-b border-swiss-black p-6 dark:border-white/20">
-							<div class="flex items-start justify-between">
-								<div>
-									<h2 class="text-lg text-swiss-black dark:text-white">{group.title}</h2>
-									<p class="mt-1 text-xs text-swiss-mid-gray dark:text-white/60">
-										{group.description}
-									</p>
+						<!-- Group header is the group drag handle / surface -->
+						<div
+							use:draggable={{
+								container: group.id,
+								dragData: { kind: 'group', group } satisfies NestedDragPayload,
+								handle: '.group-drag-handle'
+							}}
+							class="border-b border-swiss-black p-6 dark:border-white/20"
+						>
+							<div class="flex items-start justify-between gap-4">
+								<div class="flex items-start gap-3">
+									<span
+										class="group-drag-handle mt-0.5 cursor-grab select-none text-swiss-mid-gray dark:text-white/50"
+										aria-hidden="true"
+									>
+										⋮⋮
+									</span>
+									<div>
+										<h2 class="text-lg text-swiss-black dark:text-white">{group.title}</h2>
+										<p class="mt-1 text-xs text-swiss-mid-gray dark:text-white/60">
+											{group.description}
+										</p>
+									</div>
 								</div>
 								<span class="text-xs text-swiss-mid-gray dark:text-white/60"
 									>{group.items.length.toString().padStart(2, '0')}</span
@@ -174,21 +220,30 @@
 							</div>
 						</div>
 
-						<!-- Group Items -->
-						<div class="divide-y divide-swiss-gray dark:divide-white/10">
-							{#each group.items as item, itemIndex (item.id)}
+						<!-- Item list body: accepts items (including empty groups) -->
+						<div
+							use:droppable={{
+								container: `list:${group.id}`,
+								callbacks: { onDrop: handleItemDrop }
+							}}
+							class="min-h-16 divide-y divide-swiss-gray dark:divide-white/10"
+						>
+							{#each group.items as item (item.id)}
 								<div
 									use:droppable={{
-										container: `${group.id}:${itemIndex}`,
-										callbacks: {
-											onDrop: (state: DragDropState<DraggedItem>) => handleItemDrop(group.id, state)
-										}
+										container: `item:${group.id}:${item.id}`,
+										callbacks: { onDrop: handleItemDrop }
 									}}
+									animate:flip={{ duration: 150 }}
 								>
 									<div
 										use:draggable={{
-											container: `${group.id}:${itemIndex}`,
-											dragData: item
+											container: `item:${group.id}:${item.id}`,
+											dragData: {
+												kind: 'item',
+												item,
+												groupId: group.id
+											} satisfies NestedDragPayload
 										}}
 										class="svelte-dnd-touch-feedback cursor-move bg-white p-6 transition-all hover:bg-swiss-gray dark:bg-swiss-black dark:hover:bg-white/10"
 									>


### PR DESCRIPTION
## Summary

Implements the **drag lifecycle reliability** epic:

| Issue | Fix |
|-------|-----|
| **#61** | Auto-scroll waits for real pointer/drag coords; pointer path starts auto-scroll on first `pointermove` (no jump-to-top on hold) |
| **#60** | Shared `resetDndState()`; drop always finalizes session; destroy mid-drag cleans up when source unmounts after list mutation |
| **#27** | Deepest nested droppable owns hover/drop; `stopPropagation` on drop; nested demo rewritten (group reorder + item move) |

Also exports `resetDndState` from the public API.

## Test plan

- [x] `bun run test` — 89 tests pass
- [x] `bun run check` — 0 errors
- [ ] Manual: long scrollable list → hold item without move → page must not jump
- [ ] Manual: Kanban multi-column → move card between columns → `isDragging` false, no stuck indicator
- [ ] Manual: `/nested` → reorder groups via handle; move items within and across groups

Closes #61
Closes #60
Closes #27