### PR TITLE
feat: opt-in keyboard accessibility (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- **#59** — First-class `{@attach}` factories: `attachDraggable` / `attachDroppable`
-  with generics and reactive getters; demo at `/attach`; README documents correct
-  `fromAction(..., () => options)` usage
+- **#24** — Opt-in keyboard accessibility: `keyboard: true` on draggable
+  (Space/Enter grab & drop, arrows move preview, Escape cancel), droppable
+  registry, assertive live-region announcements, `/keyboard` demo
 
 ## [0.4.2](https://github.com/thisuxhq/sveltednd/compare/sveltednd-v0.4.1...sveltednd-v0.4.2) (2026-07-19)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A lightweight, flexible drag and drop library for Svelte 5 applications. Built w
 - **Drop Indicators** — Visual feedback showing exactly where items will drop
 - **Nested Support** — Works with nested containers and complex hierarchies
 - **Attachments** — First-class `{@attach}` factories for components (Svelte 5.29+)
+- **Keyboard** — Opt-in Space/arrows/Escape reordering with screen-reader announcements
 - **Lightweight** — Minimal footprint with zero external dependencies
 
 ## Installation
@@ -415,6 +416,64 @@ Explore the demo pages for complete working examples:
 - **[Interactive Elements](https://github.com/thisuxhq/SvelteDnD/blob/main/src/routes/interactive-elements/+page.svelte)** — Forms inside draggable items
 - **[Conditional Check](https://github.com/thisuxhq/SvelteDnD/blob/main/src/routes/conditional-check/+page.svelte)** — Validation before drop
 - **[Attachments](https://github.com/thisuxhq/sveltednd/blob/main/src/routes/attach/+page.svelte)** — `{@attach}` on components
+- **[Keyboard](https://github.com/thisuxhq/sveltednd/blob/main/src/routes/keyboard/+page.svelte)** — Space / arrows / Escape reordering
+
+## Keyboard accessibility (opt-in)
+
+Enable keyboard reordering with `keyboard: true` on a **draggable**. Mouse and touch
+behavior are unchanged when the option is omitted.
+
+| Key                                 | Action                                            |
+| ----------------------------------- | ------------------------------------------------- |
+| **Tab**                             | Focus a keyboard-enabled item                     |
+| **Space** / **Enter**               | Pick up, or drop while dragging                   |
+| **↑ / ↓** (or ← / → for horizontal) | Move the drop preview among registered drop zones |
+| **Escape**                          | Cancel without calling `onDrop`                   |
+
+```svelte
+<script lang="ts">
+	import { draggable, droppable, type DragDropState } from '@thisux/sveltednd';
+
+	let items = $state(['Alpha', 'Beta', 'Gamma']);
+
+	function handleDrop(state: DragDropState<string>) {
+		const from = items.indexOf(state.draggedItem);
+		let to = parseInt(state.targetContainer ?? '0');
+		if (state.dropPosition === 'after') to += 1;
+		if (from === -1) return;
+		const next = [...items];
+		const [item] = next.splice(from, 1);
+		next.splice(from < to ? to - 1 : to, 0, item);
+		items = next;
+	}
+</script>
+
+{#each items as item, index (item)}
+	<div
+		use:draggable={{
+			container: index.toString(),
+			dragData: item,
+			keyboard: true
+		}}
+		use:droppable={{
+			container: index.toString(),
+			callbacks: { onDrop: handleDrop }
+		}}
+	>
+		{item}
+	</div>
+{/each}
+```
+
+Notes:
+
+- Keyboard uses the **same** `onDrop` contract as pointer/HTML5 — your data model stays in the app.
+- An assertive live region announces grab / move / drop / cancel for screen readers.
+- Interactive children (inputs, buttons, …) still receive Space/Enter normally.
+- Cross-column Kanban keyboard navigation is planned as a follow-up (`navigation: 'containers'`).
+
+Live demo: [Keyboard](https://sveltednd.thisux.com/keyboard) ·
+[source](https://github.com/thisuxhq/sveltednd/blob/main/src/routes/keyboard/+page.svelte)
 
 ## Using with Components — `{@attach}` (Svelte 5.29+)
 

--- a/src/lib/actions/draggable.ts
+++ b/src/lib/actions/draggable.ts
@@ -29,8 +29,20 @@
  */
 
 import { dndState, resetDndState } from '$lib/stores/dnd.svelte.js';
-import type { DraggableOptions, DragDropState } from '$lib/types/index.js';
+import type { DraggableOptions, DragDropState, KeyboardOptions } from '$lib/types/index.js';
 import { startAutoScroll, stopAutoScroll } from '$lib/utils/auto-scroll.js';
+import {
+	cancelKeyboardSession,
+	isKeyboardSessionActive,
+	startKeyboardSession
+} from '$lib/utils/keyboard-session.js';
+
+/** Normalize keyboard option into options object or null when disabled. */
+function resolveKeyboardOptions(keyboard: DraggableOptions['keyboard']): KeyboardOptions | null {
+	if (keyboard === true) return { enabled: true, navigation: 'list' };
+	if (!keyboard || keyboard.enabled === false) return null;
+	return { enabled: true, navigation: 'list', ...keyboard };
+}
 
 /**
  * Default CSS class applied while dragging.
@@ -99,7 +111,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	 * drag was cancelled after hovering an invalid zone, that flag must not leak
 	 * into the next drag.
 	 */
-	function beginDragState() {
+	function beginDragState(input: 'html5' | 'pointer' | 'keyboard' = 'pointer') {
 		dndState.isDragging = true;
 		dndState.draggedItem = options.dragData;
 		dndState.sourceContainer = options.container;
@@ -107,6 +119,50 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		dndState.targetElement = null;
 		dndState.dropPosition = null;
 		dndState.invalidDrop = false;
+		dndState.dragInput = input;
+	}
+
+	function getItemLabel(): string {
+		const data = options.dragData as { title?: string; name?: string; id?: string } | unknown;
+		if (data && typeof data === 'object') {
+			const o = data as { title?: string; name?: string; id?: string };
+			if (o.title) return String(o.title);
+			if (o.name) return String(o.name);
+			if (o.id !== undefined) return String(o.id);
+		}
+		if (typeof data === 'string' || typeof data === 'number') return String(data);
+		const text = node.textContent?.trim();
+		return text ? text.slice(0, 80) : 'Item';
+	}
+
+	function applyKeyboardFocusability() {
+		const kb = resolveKeyboardOptions(options.keyboard);
+		if (options.disabled || !kb) {
+			if (node.getAttribute('data-sveltednd-keyboard') === 'true') {
+				node.removeAttribute('tabindex');
+				node.removeAttribute('data-sveltednd-keyboard');
+				node.removeAttribute('aria-describedby');
+				node.removeAttribute('aria-grabbed');
+			}
+			return;
+		}
+
+		// Prefer focusing the handle when one is configured
+		if (options.handle) {
+			const handleEl = node.querySelector(options.handle) as HTMLElement | null;
+			if (handleEl) {
+				handleEl.tabIndex = 0;
+				handleEl.setAttribute('data-sveltednd-keyboard-handle', 'true');
+			}
+		}
+		node.tabIndex = 0;
+		node.setAttribute('data-sveltednd-keyboard', 'true');
+		node.setAttribute('aria-grabbed', 'false');
+		// Instructions id is created lazily by live region; describe operation statically
+		node.setAttribute(
+			'aria-roledescription',
+			'draggable. Press Space or Enter to pick up, arrow keys to move, Space or Enter to drop, Escape to cancel.'
+		);
 	}
 
 	/**
@@ -130,7 +186,13 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		html5DragActive = false;
 		removePointerListeners();
 		stopAutoScroll();
+		// Keyboard session owns its own teardown (onDragEnd + reset)
+		if (isKeyboardSessionActive()) {
+			cancelKeyboardSession();
+			return;
+		}
 		node.classList.remove(...draggingClass);
+		if (node.isConnected) node.setAttribute('aria-grabbed', 'false');
 		// Best-effort: if this node was already removed, also clear any leftover class
 		document.querySelectorAll(`.${draggingClass[0]}`).forEach((el) => {
 			if (el instanceof HTMLElement) el.classList.remove(...draggingClass);
@@ -177,6 +239,11 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	 */
 	function handleDragStart(event: DragEvent) {
 		if (options.disabled) return;
+		// Keyboard session owns the drag — do not start HTML5 in parallel
+		if (isKeyboardSessionActive() || dndState.dragInput === 'keyboard') {
+			event.preventDefault();
+			return;
+		}
 
 		// Use the element that was actually pressed (captured in pointerdown), not
 		// event.target — dragstart always reports the draggable container as target,
@@ -201,7 +268,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		html5DragActive = true;
 
 		// Update global state - this triggers reactive updates across all components
-		beginDragState();
+		beginDragState('html5');
 
 		// Configure the native drag data transfer
 		// We stringify the data so it works across different browser contexts
@@ -257,13 +324,15 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 		pointerDownTarget = event.target as HTMLElement;
 
 		if (options.disabled) return;
+		// Do not start pointer drag while keyboard session is active
+		if (isKeyboardSessionActive() || dndState.dragInput === 'keyboard') return;
 
 		if (!isHandleElement(event.target as HTMLElement)) return;
 
 		if (!options.handle && isInteractiveElement(event.target as HTMLElement)) return;
 
 		// Initialize the drag state (same as HTML5 path)
-		beginDragState();
+		beginDragState('pointer');
 
 		// Visual feedback
 		node.classList.add(...draggingClass);
@@ -305,7 +374,44 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	 */
 	function handlePointerCancel(event: PointerEvent) {
 		if (html5DragActive) return;
+		if (isKeyboardSessionActive() || dndState.dragInput === 'keyboard') return;
 		handlePointerUp(event);
+	}
+
+	/**
+	 * Keyboard grab entry (Space / Enter) when `keyboard: true` (#24).
+	 * Arrow / drop / cancel are handled on document by keyboard-session.
+	 */
+	function handleKeyDown(event: KeyboardEvent) {
+		const kb = resolveKeyboardOptions(options.keyboard);
+		if (!kb || options.disabled) return;
+
+		// Already in a keyboard session — document handler owns keys
+		if (isKeyboardSessionActive()) return;
+
+		const target = event.target as HTMLElement;
+		// Never hijack typing / native control activation
+		if (isInteractiveElement(target) && target !== node) return;
+
+		if (options.handle && !isHandleElement(target) && target !== node) return;
+
+		if (event.key !== ' ' && event.key !== 'Enter') return;
+		if (dndState.isDragging) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		startKeyboardSession({
+			sourceElement: node,
+			sourceContainer: options.container,
+			dragData: options.dragData,
+			draggingClass,
+			direction: options.direction ?? 'vertical',
+			keyboard: kb,
+			itemLabel: getItemLabel(),
+			onDragStart: options.callbacks?.onDragStart as ((state: DragDropState) => void) | undefined,
+			onDragEnd: options.callbacks?.onDragEnd as ((state: DragDropState) => void) | undefined
+		});
 	}
 
 	/**
@@ -373,6 +479,10 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 	// Pointer events for broader device support
 	node.addEventListener('pointerdown', handlePointerDown);
 
+	// Keyboard accessibility (opt-in via keyboard: true) — issue #24
+	node.addEventListener('keydown', handleKeyDown);
+	applyKeyboardFocusability();
+
 	// Return Svelte action lifecycle methods
 	return {
 		/**
@@ -385,6 +495,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 			node.draggable = !options.disabled;
 			node.style.touchAction = options.disabled ? '' : 'none';
 			node.style.userSelect = options.disabled ? '' : 'none';
+			applyKeyboardFocusability();
 		},
 
 		/**
@@ -399,6 +510,10 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 			node.removeEventListener('dragstart', handleDragStart);
 			node.removeEventListener('dragend', handleDragEnd);
 			node.removeEventListener('pointerdown', handlePointerDown);
+			node.removeEventListener('keydown', handleKeyDown);
+			node.removeAttribute('data-sveltednd-keyboard');
+			node.removeAttribute('aria-roledescription');
+			node.removeAttribute('aria-grabbed');
 
 			// If this node is destroyed mid-drag (common when onDrop reorders lists
 			// and the source element unmounts before dragend), force full cleanup (#60).
@@ -410,6 +525,7 @@ export function draggable<T>(node: HTMLElement, options: DraggableOptions<T>) {
 				finishDrag();
 			} else {
 				removePointerListeners();
+				if (isKeyboardSessionActive()) cancelKeyboardSession();
 			}
 		}
 	};

--- a/src/lib/actions/droppable.ts
+++ b/src/lib/actions/droppable.ts
@@ -41,6 +41,11 @@ import {
 	removeScrollExclusion,
 	stopAutoScroll
 } from '$lib/utils/auto-scroll.js';
+import {
+	registerDroppable,
+	unregisterDroppable,
+	type DroppableRegistration
+} from '$lib/utils/dnd-registry.js';
 
 /**
  * Default CSS class applied when an item is dragged over this element.
@@ -566,10 +571,60 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		}
 	}
 
+	/**
+	 * Keyboard hover preview — reuses drag-over class + drop indicators (#24).
+	 */
+	function setKeyboardHover(active: boolean, position: 'before' | 'after' | null = null) {
+		if (active) {
+			addDragOverClass();
+			if (position) {
+				setDropIndicator(position);
+			}
+			options.callbacks?.onDragOver?.(dndState as DragDropState<T>);
+		} else {
+			removeDragOverClass();
+			clearDropIndicator();
+		}
+	}
+
+	/**
+	 * Keyboard drop commit — same onDrop + finalize pipeline as pointer (#24).
+	 */
+	async function commitDrop(state: DragDropState) {
+		if (options.disabled) return;
+
+		dragEnterCounter = 0;
+		removeDragOverClass();
+
+		const dropState = { ...state } as DragDropState<T>;
+		dndState.targetContainer = options.container;
+		dndState.targetElement = node;
+
+		try {
+			await options.callbacks?.onDrop?.(dropState);
+		} catch (error) {
+			console.error('Drop handling failed:', error);
+		} finally {
+			finalizeDropSession();
+		}
+	}
+
+	const registration: DroppableRegistration = {
+		element: node,
+		container: options.container,
+		direction: options.direction ?? 'vertical',
+		disabled: !!options.disabled,
+		setKeyboardHover,
+		commitDrop
+	};
+
 	// === Setup: Attach all event listeners ===
 
 	// Marker for nested deepest-target resolution (#27)
 	node.setAttribute('data-sveltednd-droppable', options.container);
+
+	// Keyboard navigation registry (#24)
+	registerDroppable(registration);
 
 	// HTML5 drag API events
 	node.addEventListener('dragenter', handleDragEnter);
@@ -618,6 +673,11 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 			dragOverClass = getDragOverClass(options);
 			node.setAttribute('data-sveltednd-droppable', options.container);
 
+			// Keep keyboard registry in sync
+			registration.container = options.container;
+			registration.direction = options.direction ?? 'vertical';
+			registration.disabled = !!options.disabled;
+
 			removeDragOverClass(previousDragOverClass);
 			if (hadActiveState) addDragOverClass();
 		},
@@ -628,6 +688,7 @@ export function droppable<T>(node: HTMLElement, options: DragDropOptions<T>) {
 		 * Removes all event listeners and clears any visual indicators.
 		 */
 		destroy() {
+			unregisterDroppable(registration);
 			clearDropIndicator();
 			removeDragOverClass();
 			clearTargetState();

--- a/src/lib/stores/dnd.svelte.ts
+++ b/src/lib/stores/dnd.svelte.ts
@@ -55,7 +55,9 @@ export const dndState = $state<DragDropState>({
 	 * Set to true when hovering over an invalid drop zone.
 	 * Can be used to show red highlighting or other error states.
 	 */
-	invalidDrop: false
+	invalidDrop: false,
+	/** Input path for the active drag; null when idle */
+	dragInput: null
 });
 
 /**
@@ -73,4 +75,5 @@ export function resetDndState(): void {
 	dndState.targetElement = null;
 	dndState.dropPosition = null;
 	dndState.invalidDrop = false;
+	dndState.dragInput = null;
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -33,6 +33,9 @@
  *
  * @typeParam T - The type of data being dragged (your item type)
  */
+/** Which input path started the current drag session (when active). */
+export type DragInputMode = 'html5' | 'pointer' | 'keyboard';
+
 export interface DragDropState<T = unknown> {
 	/** True while the user is actively dragging (from dragstart to dragend) */
 	isDragging: boolean;
@@ -62,6 +65,11 @@ export interface DragDropState<T = unknown> {
 	 * Useful for showing visual feedback (e.g., red highlighting).
 	 */
 	invalidDrop?: boolean;
+	/**
+	 * Input modality for the active drag, when dragging.
+	 * `null` when idle. Additive — safe for apps that ignore it.
+	 */
+	dragInput?: DragInputMode | null;
 }
 
 /**
@@ -188,6 +196,49 @@ export interface DragDropOptions<T = unknown> {
 }
 
 /**
+ * Context passed to keyboard announcement formatters.
+ */
+export interface KeyboardAnnouncementContext {
+	/** Human-readable label for the item when available */
+	itemLabel: string;
+	/** Source container id */
+	sourceContainer: string;
+	/** Current target container id (if any) */
+	targetContainer: string | null;
+	/** 1-based index among keyboard targets, or null */
+	position: number | null;
+	/** Total keyboard targets considered */
+	total: number | null;
+}
+
+/**
+ * Opt-in keyboard drag configuration (issue #24).
+ *
+ * Default is off so existing apps get zero tabindex/listener changes until
+ * they enable `keyboard: true` on a draggable.
+ */
+export interface KeyboardOptions {
+	/**
+	 * When false, keyboard support is disabled even if the object is present.
+	 * @default true when `keyboard` is an object or `true`
+	 */
+	enabled?: boolean;
+	/**
+	 * - `'list'` (default): arrows move among registered droppables along the axis
+	 * - `'containers'`: reserved for multi-column navigation (future)
+	 */
+	navigation?: 'list' | 'containers';
+	/** Override screen-reader announcements (assertive live region) */
+	announcements?: {
+		grabbed?: (ctx: KeyboardAnnouncementContext) => string;
+		moved?: (ctx: KeyboardAnnouncementContext) => string;
+		dropped?: (ctx: KeyboardAnnouncementContext) => string;
+		cancelled?: (ctx: KeyboardAnnouncementContext) => string;
+		invalid?: (ctx: KeyboardAnnouncementContext) => string;
+	};
+}
+
+/**
  * Configuration options specifically for draggable elements.
  *
  * Extends the base DragDropOptions with features for controlling
@@ -216,4 +267,13 @@ export interface DraggableOptions<T = unknown> extends DragDropOptions<T> {
 	 * '.drag-handle', '[data-drag-handle]'
 	 */
 	handle?: string;
+	/**
+	 * Enable keyboard reordering for this item (Space/Enter grab & drop,
+	 * arrows to move, Escape to cancel). Opt-in to avoid changing Tab order
+	 * in existing apps. Works with `attachDraggable` as well.
+	 *
+	 * @example
+	 * use:draggable={{ container: '0', dragData: item, keyboard: true }}
+	 */
+	keyboard?: boolean | KeyboardOptions;
 }

--- a/src/lib/utils/dnd-registry.spec.ts
+++ b/src/lib/utils/dnd-registry.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	registerDroppable,
+	unregisterDroppable,
+	listKeyboardTargets,
+	indexOfElement,
+	_testing,
+	type DroppableRegistration
+} from './dnd-registry.js';
+
+function makeEntry(
+	el: HTMLElement,
+	container: string,
+	overrides: Partial<DroppableRegistration> = {}
+): DroppableRegistration {
+	return {
+		element: el,
+		container,
+		direction: 'vertical',
+		disabled: false,
+		setKeyboardHover: () => {},
+		commitDrop: () => {},
+		...overrides
+	};
+}
+
+describe('dnd-registry', () => {
+	beforeEach(() => {
+		_testing.clearAll();
+	});
+
+	it('registers and unregisters droppables', () => {
+		const el = document.createElement('div');
+		document.body.appendChild(el);
+		const entry = makeEntry(el, 'a');
+		registerDroppable(entry);
+		expect(_testing.size()).toBe(1);
+		unregisterDroppable(entry);
+		expect(_testing.size()).toBe(0);
+		el.remove();
+	});
+
+	it('sorts targets top-to-bottom for vertical lists', () => {
+		const a = document.createElement('div');
+		const b = document.createElement('div');
+		document.body.appendChild(a);
+		document.body.appendChild(b);
+
+		vi.spyOn(a, 'getBoundingClientRect').mockReturnValue({
+			top: 100,
+			left: 0,
+			bottom: 140,
+			right: 100,
+			width: 100,
+			height: 40,
+			x: 0,
+			y: 100,
+			toJSON: () => ({})
+		});
+		vi.spyOn(b, 'getBoundingClientRect').mockReturnValue({
+			top: 20,
+			left: 0,
+			bottom: 60,
+			right: 100,
+			width: 100,
+			height: 40,
+			x: 0,
+			y: 20,
+			toJSON: () => ({})
+		});
+
+		registerDroppable(makeEntry(a, '1'));
+		registerDroppable(makeEntry(b, '0'));
+
+		const targets = listKeyboardTargets('vertical');
+		expect(targets.map((t) => t.container)).toEqual(['0', '1']);
+
+		a.remove();
+		b.remove();
+	});
+
+	it('prefers deepest droppables over ancestors', () => {
+		const parent = document.createElement('div');
+		const child = document.createElement('div');
+		parent.appendChild(child);
+		document.body.appendChild(parent);
+
+		vi.spyOn(parent, 'getBoundingClientRect').mockReturnValue({
+			top: 0,
+			left: 0,
+			bottom: 200,
+			right: 200,
+			width: 200,
+			height: 200,
+			x: 0,
+			y: 0,
+			toJSON: () => ({})
+		});
+		vi.spyOn(child, 'getBoundingClientRect').mockReturnValue({
+			top: 10,
+			left: 10,
+			bottom: 50,
+			right: 50,
+			width: 40,
+			height: 40,
+			x: 10,
+			y: 10,
+			toJSON: () => ({})
+		});
+
+		registerDroppable(makeEntry(parent, 'parent'));
+		registerDroppable(makeEntry(child, 'child'));
+
+		const targets = listKeyboardTargets('vertical');
+		expect(targets).toHaveLength(1);
+		expect(targets[0].container).toBe('child');
+
+		parent.remove();
+	});
+
+	it('indexOfElement finds containing registration', () => {
+		const el = document.createElement('div');
+		const inner = document.createElement('span');
+		el.appendChild(inner);
+		document.body.appendChild(el);
+		const entry = makeEntry(el, 'x');
+		registerDroppable(entry);
+		const targets = [entry];
+		expect(indexOfElement(targets, inner)).toBe(0);
+		el.remove();
+	});
+});

--- a/src/lib/utils/dnd-registry.ts
+++ b/src/lib/utils/dnd-registry.ts
@@ -1,0 +1,107 @@
+/**
+ * Registry of active droppable zones for keyboard navigation (#24).
+ *
+ * Droppables register on mount and unregister on destroy. Keyboard sessions
+ * query this list (sorted by geometry) instead of inventing list indexes.
+ *
+ * @module dnd-registry
+ */
+
+import type { DragDropState } from '$lib/types/index.js';
+
+export type DroppableDirection = 'vertical' | 'horizontal' | 'grid';
+
+export interface DroppableRegistration {
+	/** DOM node for this drop zone */
+	element: HTMLElement;
+	/** Container id (same as droppable options.container) */
+	container: string;
+	direction: DroppableDirection;
+	disabled: boolean;
+	/**
+	 * Apply or clear visual hover for keyboard preview.
+	 * position is used for drop indicators when hovering.
+	 */
+	setKeyboardHover: (active: boolean, position?: 'before' | 'after' | null) => void;
+	/**
+	 * Commit a drop using the same pipeline as pointer/HTML5.
+	 * Receives a snapshot of dndState at drop time.
+	 */
+	commitDrop: (state: DragDropState) => void | Promise<void>;
+}
+
+const droppables = new Set<DroppableRegistration>();
+
+export function registerDroppable(entry: DroppableRegistration): void {
+	droppables.add(entry);
+}
+
+export function unregisterDroppable(entry: DroppableRegistration): void {
+	droppables.delete(entry);
+}
+
+export function getRegisteredDroppables(): DroppableRegistration[] {
+	return [...droppables];
+}
+
+/**
+ * Returns enabled droppables sorted along an axis for keyboard stepping.
+ * Nested parents that fully contain a registered child are omitted so the
+ * deepest zones win (same spirit as #27).
+ */
+export function listKeyboardTargets(
+	direction: DroppableDirection = 'vertical'
+): DroppableRegistration[] {
+	const enabled = [...droppables].filter((d) => !d.disabled && d.element.isConnected);
+
+	// Prefer deepest: drop a zone if another registered zone is contained inside it
+	const deepest = enabled.filter(
+		(candidate) =>
+			!enabled.some((other) => other !== candidate && candidate.element.contains(other.element))
+	);
+
+	const axis = direction === 'horizontal' ? 'x' : 'y';
+
+	return deepest.sort((a, b) => {
+		const ra = a.element.getBoundingClientRect();
+		const rb = b.element.getBoundingClientRect();
+		if (axis === 'y') {
+			const dy = ra.top - rb.top;
+			if (Math.abs(dy) > 1) return dy;
+			return ra.left - rb.left;
+		}
+		const dx = ra.left - rb.left;
+		if (Math.abs(dx) > 1) return dx;
+		return ra.top - rb.top;
+	});
+}
+
+/**
+ * Find the index of a registration that owns `element` or contains it.
+ */
+export function indexOfElement(
+	targets: DroppableRegistration[],
+	element: HTMLElement | null
+): number {
+	if (!element) return -1;
+	return targets.findIndex(
+		(t) => t.element === element || t.element.contains(element) || element.contains(t.element)
+	);
+}
+
+/** Clear keyboard hover on all registered droppables. */
+export function clearAllKeyboardHovers(): void {
+	for (const d of droppables) {
+		d.setKeyboardHover(false, null);
+	}
+}
+
+/** Testing helpers */
+export const _testing = {
+	clearAll() {
+		droppables.clear();
+	},
+	size() {
+		return droppables.size;
+	}
+};

--- a/src/lib/utils/keyboard-dnd.spec.ts
+++ b/src/lib/utils/keyboard-dnd.spec.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { draggable } from '../actions/draggable.js';
+import { droppable } from '../actions/droppable.js';
+import { dndState } from '../stores/dnd.svelte.js';
+import { _testing as registryTesting } from './dnd-registry.js';
+import { _testing as sessionTesting, isKeyboardSessionActive } from './keyboard-session.js';
+import { destroyLiveRegion } from './live-region.js';
+
+describe('keyboard accessibility (issue #24)', () => {
+	let items: HTMLElement[];
+	let actions: Array<{ destroy: () => void }>;
+
+	beforeEach(() => {
+		sessionTesting.reset();
+		registryTesting.clearAll();
+		destroyLiveRegion();
+		dndState.isDragging = false;
+		dndState.draggedItem = null;
+		dndState.sourceContainer = '';
+		dndState.targetContainer = null;
+		dndState.dragInput = null;
+		items = [];
+		actions = [];
+
+		// Three stacked drop/drag items (simple-list pattern)
+		for (let i = 0; i < 3; i++) {
+			const el = document.createElement('div');
+			el.textContent = `Item ${i}`;
+			document.body.appendChild(el);
+			vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+				top: i * 50,
+				left: 0,
+				bottom: i * 50 + 40,
+				right: 200,
+				width: 200,
+				height: 40,
+				x: 0,
+				y: i * 50,
+				toJSON: () => ({})
+			});
+			items.push(el);
+		}
+	});
+
+	afterEach(() => {
+		for (const a of actions) a.destroy();
+		for (const el of items) el.remove();
+		sessionTesting.reset();
+		registryTesting.clearAll();
+		destroyLiveRegion();
+	});
+
+	function mountList(onDrop = vi.fn()) {
+		items.forEach((el, i) => {
+			actions.push(
+				draggable(el, {
+					container: String(i),
+					dragData: { id: String(i), title: `Item ${i}` },
+					keyboard: true
+				})
+			);
+			actions.push(
+				droppable(el, {
+					container: String(i),
+					callbacks: { onDrop }
+				})
+			);
+		});
+		return onDrop;
+	}
+
+	it('does not set tabindex when keyboard is off', () => {
+		const el = items[0];
+		const action = draggable(el, { container: '0', dragData: 1 });
+		actions.push(action);
+		expect(el.getAttribute('data-sveltednd-keyboard')).toBeNull();
+		expect(el.tabIndex).toBeLessThan(0);
+	});
+
+	it('sets tabindex when keyboard is enabled', () => {
+		const el = items[0];
+		const action = draggable(el, { container: '0', dragData: 1, keyboard: true });
+		actions.push(action);
+		expect(el.tabIndex).toBe(0);
+		expect(el.getAttribute('data-sveltednd-keyboard')).toBe('true');
+	});
+
+	it('grabs on Space and sets keyboard dragInput', () => {
+		mountList();
+		const el = items[0];
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
+
+		expect(isKeyboardSessionActive()).toBe(true);
+		expect(dndState.isDragging).toBe(true);
+		expect(dndState.dragInput).toBe('keyboard');
+		expect(dndState.draggedItem).toEqual({ id: '0', title: 'Item 0' });
+		expect(el.getAttribute('aria-grabbed')).toBe('true');
+	});
+
+	it('moves target with ArrowDown and drops with Space', async () => {
+		const onDrop = mountList();
+		const el = items[0];
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
+
+		document.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+		);
+		expect(dndState.targetContainer).toBe('1');
+
+		document.dispatchEvent(
+			new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
+		);
+
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(onDrop).toHaveBeenCalled();
+		expect(isKeyboardSessionActive()).toBe(false);
+		expect(dndState.isDragging).toBe(false);
+		expect(dndState.dragInput).toBeNull();
+	});
+
+	it('cancels on Escape without calling onDrop', async () => {
+		const onDrop = mountList();
+		items[0].dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+		);
+		expect(dndState.isDragging).toBe(true);
+
+		document.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+		);
+
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(onDrop).not.toHaveBeenCalled();
+		expect(dndState.isDragging).toBe(false);
+		expect(isKeyboardSessionActive()).toBe(false);
+	});
+
+	it('does not grab when focus is on an interactive child', () => {
+		const el = items[0];
+		const input = document.createElement('input');
+		el.appendChild(input);
+		actions.push(
+			draggable(el, {
+				container: '0',
+				dragData: { id: '0' },
+				keyboard: true
+			})
+		);
+
+		input.dispatchEvent(
+			new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
+		);
+		expect(dndState.isDragging).toBe(false);
+		expect(isKeyboardSessionActive()).toBe(false);
+	});
+});

--- a/src/lib/utils/keyboard-session.ts
+++ b/src/lib/utils/keyboard-session.ts
@@ -1,0 +1,294 @@
+/**
+ * Keyboard drag session — grab / arrow-move / drop / cancel (#24).
+ *
+ * Shares dndState and droppable commitDrop with pointer/HTML5 paths.
+ * Opt-in only (started from draggable when keyboard: true).
+ *
+ * @module keyboard-session
+ */
+
+import { dndState, resetDndState } from '$lib/stores/dnd.svelte.js';
+import type {
+	DragDropState,
+	KeyboardAnnouncementContext,
+	KeyboardOptions
+} from '$lib/types/index.js';
+import {
+	clearAllKeyboardHovers,
+	indexOfElement,
+	listKeyboardTargets,
+	type DroppableDirection,
+	type DroppableRegistration
+} from './dnd-registry.js';
+import { announce } from './live-region.js';
+import { stopAutoScroll } from './auto-scroll.js';
+
+export interface KeyboardSessionConfig {
+	sourceElement: HTMLElement;
+	sourceContainer: string;
+	dragData: unknown;
+	draggingClass: string[];
+	direction: DroppableDirection;
+	keyboard: KeyboardOptions;
+	itemLabel: string;
+	onDragStart?: (state: DragDropState) => void;
+	onDragEnd?: (state: DragDropState) => void;
+}
+
+interface Session {
+	config: KeyboardSessionConfig;
+	targets: DroppableRegistration[];
+	targetIndex: number;
+	documentKeyHandler: (event: KeyboardEvent) => void;
+}
+
+let session: Session | null = null;
+
+export function isKeyboardSessionActive(): boolean {
+	return session !== null;
+}
+
+function buildContext(): KeyboardAnnouncementContext {
+	if (!session) {
+		return {
+			itemLabel: '',
+			sourceContainer: '',
+			targetContainer: null,
+			position: null,
+			total: null
+		};
+	}
+	const { config, targets, targetIndex } = session;
+	const target = targets[targetIndex];
+	return {
+		itemLabel: config.itemLabel,
+		sourceContainer: config.sourceContainer,
+		targetContainer: target?.container ?? null,
+		position: targets.length ? targetIndex + 1 : null,
+		total: targets.length || null
+	};
+}
+
+function defaultAnnouncements() {
+	return {
+		grabbed: (ctx: KeyboardAnnouncementContext) =>
+			`${ctx.itemLabel || 'Item'} grabbed. Current position ${ctx.position} of ${ctx.total}. ` +
+			`Use arrow keys to change position, Space or Enter to drop, Escape to cancel.`,
+		moved: (ctx: KeyboardAnnouncementContext) =>
+			`${ctx.itemLabel || 'Item'}. Position ${ctx.position} of ${ctx.total}.`,
+		dropped: (ctx: KeyboardAnnouncementContext) =>
+			`${ctx.itemLabel || 'Item'} dropped. Final position ${ctx.position} of ${ctx.total}.`,
+		cancelled: (ctx: KeyboardAnnouncementContext) =>
+			`${ctx.itemLabel || 'Item'} reorder cancelled.`,
+		invalid: (ctx: KeyboardAnnouncementContext) => `Cannot drop ${ctx.itemLabel || 'item'} here.`
+	};
+}
+
+function announceWith(
+	kind: keyof ReturnType<typeof defaultAnnouncements>,
+	overrides?: KeyboardOptions['announcements']
+) {
+	const defaults = defaultAnnouncements();
+	const formatter = overrides?.[kind] ?? defaults[kind];
+	announce(formatter(buildContext()));
+}
+
+function applyTargetPreview(): void {
+	if (!session) return;
+	clearAllKeyboardHovers();
+
+	const target = session.targets[session.targetIndex];
+	if (!target) {
+		dndState.targetContainer = null;
+		dndState.targetElement = null;
+		dndState.dropPosition = null;
+		return;
+	}
+
+	// Drop "on" a slot: use before when moving toward lower indices conceptually,
+	// after when the target is the same as source — apps using index containers
+	// read targetContainer + dropPosition the same as pointer path.
+	const position: 'before' | 'after' =
+		session.targetIndex >= indexOfElement(session.targets, session.config.sourceElement)
+			? 'after'
+			: 'before';
+
+	dndState.targetContainer = target.container;
+	dndState.targetElement = target.element;
+	dndState.dropPosition = position;
+	dndState.invalidDrop = false;
+
+	target.setKeyboardHover(true, position);
+
+	// Allow apps to mark invalidDrop via onDragOver if they registered callbacks
+	// through the droppable options (invoked inside setKeyboardHover if wired).
+}
+
+function finishSession(options: { announceKind?: 'dropped' | 'cancelled' | 'invalid' | null }) {
+	if (!session) return;
+	const { config, documentKeyHandler } = session;
+
+	document.removeEventListener('keydown', documentKeyHandler, true);
+	clearAllKeyboardHovers();
+	stopAutoScroll();
+
+	config.sourceElement.classList.remove(...config.draggingClass);
+	config.sourceElement.removeAttribute('aria-grabbed');
+
+	if (options.announceKind) {
+		announceWith(options.announceKind, config.keyboard.announcements);
+	}
+
+	const endState = { ...dndState } as DragDropState;
+	config.onDragEnd?.(endState);
+
+	session = null;
+	resetDndState();
+}
+
+async function commitDrop(): Promise<void> {
+	if (!session) return;
+
+	if (dndState.invalidDrop) {
+		finishSession({ announceKind: 'invalid' });
+		return;
+	}
+
+	const target = session.targets[session.targetIndex];
+	if (!target) {
+		finishSession({ announceKind: 'cancelled' });
+		return;
+	}
+
+	const dropState = { ...dndState } as DragDropState;
+	const { config, documentKeyHandler } = session;
+
+	document.removeEventListener('keydown', documentKeyHandler, true);
+	clearAllKeyboardHovers();
+	stopAutoScroll();
+	config.sourceElement.classList.remove(...config.draggingClass);
+	config.sourceElement.removeAttribute('aria-grabbed');
+
+	try {
+		await target.commitDrop(dropState);
+	} catch (error) {
+		console.error('Keyboard drop handling failed:', error);
+	}
+
+	announceWith('dropped', config.keyboard.announcements);
+	const endState = { ...dndState } as DragDropState;
+	// commitDrop may have already reset global state (#60); still fire onDragEnd
+	config.onDragEnd?.(endState.isDragging ? endState : dropState);
+	session = null;
+	if (dndState.isDragging) {
+		resetDndState();
+	}
+}
+
+function handleDocumentKeydown(event: KeyboardEvent): void {
+	if (!session) return;
+
+	const key = event.key;
+
+	if (key === 'Escape') {
+		event.preventDefault();
+		event.stopPropagation();
+		finishSession({ announceKind: 'cancelled' });
+		return;
+	}
+
+	if (key === ' ' || key === 'Enter') {
+		event.preventDefault();
+		event.stopPropagation();
+		void commitDrop();
+		return;
+	}
+
+	const direction = session.config.direction;
+	const horizontal = direction === 'horizontal';
+	let delta = 0;
+
+	if (horizontal) {
+		if (key === 'ArrowRight' || key === 'ArrowDown') delta = 1;
+		if (key === 'ArrowLeft' || key === 'ArrowUp') delta = -1;
+	} else {
+		// vertical + grid: prefer vertical arrows; also allow horizontal as secondary
+		if (key === 'ArrowDown' || key === 'ArrowRight') delta = 1;
+		if (key === 'ArrowUp' || key === 'ArrowLeft') delta = -1;
+	}
+
+	if (delta === 0) return;
+
+	event.preventDefault();
+	event.stopPropagation();
+
+	const next = Math.max(0, Math.min(session.targets.length - 1, session.targetIndex + delta));
+	if (next === session.targetIndex) return;
+
+	session.targetIndex = next;
+	applyTargetPreview();
+	announceWith('moved', session.config.keyboard.announcements);
+}
+
+/**
+ * Starts a keyboard drag session from a focused draggable.
+ * No-ops if a session is already active.
+ */
+export function startKeyboardSession(config: KeyboardSessionConfig): void {
+	if (session) return;
+	if (dndState.isDragging) return;
+
+	const targets = listKeyboardTargets(config.direction);
+	if (targets.length === 0) return;
+
+	let targetIndex = indexOfElement(targets, config.sourceElement);
+	if (targetIndex < 0) targetIndex = 0;
+
+	const documentKeyHandler = handleDocumentKeydown;
+
+	session = {
+		config,
+		targets,
+		targetIndex,
+		documentKeyHandler
+	};
+
+	dndState.isDragging = true;
+	dndState.draggedItem = config.dragData;
+	dndState.sourceContainer = config.sourceContainer;
+	dndState.targetContainer = null;
+	dndState.targetElement = null;
+	dndState.dropPosition = null;
+	dndState.invalidDrop = false;
+	dndState.dragInput = 'keyboard';
+
+	config.sourceElement.classList.add(...config.draggingClass);
+	config.sourceElement.setAttribute('aria-grabbed', 'true');
+
+	document.addEventListener('keydown', documentKeyHandler, true);
+
+	applyTargetPreview();
+	config.onDragStart?.(dndState as DragDropState);
+	announceWith('grabbed', config.keyboard.announcements);
+}
+
+/**
+ * Cancel any active keyboard session (e.g. draggable destroy).
+ */
+export function cancelKeyboardSession(): void {
+	if (!session) return;
+	finishSession({ announceKind: null });
+}
+
+/** Testing helpers */
+export const _testing = {
+	getSession: () => session,
+	reset() {
+		if (session) {
+			document.removeEventListener('keydown', session.documentKeyHandler, true);
+			session = null;
+		}
+		clearAllKeyboardHovers();
+		resetDndState();
+	}
+};

--- a/src/lib/utils/live-region.spec.ts
+++ b/src/lib/utils/live-region.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { announce, destroyLiveRegion, _testing } from './live-region.js';
+
+describe('live-region', () => {
+	afterEach(() => {
+		destroyLiveRegion();
+		vi.restoreAllMocks();
+	});
+
+	it('creates an assertive live region on first announce', async () => {
+		vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+			cb(0);
+			return 0;
+		});
+
+		announce('Item grabbed');
+		const el = document.getElementById(_testing.LIVE_REGION_ID);
+		expect(el).not.toBeNull();
+		expect(el?.getAttribute('aria-live')).toBe('assertive');
+		expect(el?.textContent).toBe('Item grabbed');
+	});
+
+	it('ignores empty messages', () => {
+		announce('');
+		expect(document.getElementById(_testing.LIVE_REGION_ID)).toBeNull();
+	});
+});

--- a/src/lib/utils/live-region.ts
+++ b/src/lib/utils/live-region.ts
@@ -1,0 +1,70 @@
+/**
+ * Assertive ARIA live region for keyboard drag announcements (#24).
+ *
+ * Creates a single visually-hidden region on first use and reuses it for
+ * all subsequent announces so screen readers get immediate status updates.
+ *
+ * @module live-region
+ */
+
+const LIVE_REGION_ID = 'sveltednd-live-region';
+
+let region: HTMLElement | null = null;
+
+function ensureRegion(): HTMLElement | null {
+	if (typeof document === 'undefined') return null;
+
+	if (region && document.body.contains(region)) return region;
+
+	const existing = document.getElementById(LIVE_REGION_ID);
+	if (existing) {
+		region = existing;
+		return region;
+	}
+
+	const el = document.createElement('div');
+	el.id = LIVE_REGION_ID;
+	el.setAttribute('role', 'status');
+	el.setAttribute('aria-live', 'assertive');
+	el.setAttribute('aria-atomic', 'true');
+	// Visually hidden but available to AT
+	el.style.cssText =
+		'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;';
+	document.body.appendChild(el);
+	region = el;
+	return region;
+}
+
+/**
+ * Announces a message to assistive technology via an assertive live region.
+ * Empty strings are ignored. The region is cleared briefly before setting
+ * text so repeated identical messages are still announced.
+ */
+export function announce(message: string): void {
+	if (!message) return;
+	const el = ensureRegion();
+	if (!el) return;
+
+	el.textContent = '';
+	// Force a DOM tick so AT picks up the next string even if identical
+	requestAnimationFrame(() => {
+		el.textContent = message;
+	});
+}
+
+/** Remove the live region (tests / full teardown). */
+export function destroyLiveRegion(): void {
+	if (region?.parentNode) {
+		region.parentNode.removeChild(region);
+	}
+	region = null;
+	const existing = typeof document !== 'undefined' ? document.getElementById(LIVE_REGION_ID) : null;
+	existing?.remove();
+}
+
+/** Testing helpers */
+export const _testing = {
+	LIVE_REGION_ID,
+	ensureRegion,
+	getRegion: () => region
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,7 +16,8 @@
 		{ path: '/drag-handle', title: 'drag handle', number: '08' },
 		{ path: '/interactive-elements', title: 'interactive elements', number: '09' },
 		{ path: '/conditional-check', title: 'conditional check', number: '10' },
-		{ path: '/attach', title: 'attachments', number: '11' }
+		{ path: '/attach', title: 'attachments', number: '11' },
+		{ path: '/keyboard', title: 'keyboard', number: '12' }
 	];
 
 	const cn = (...classes: string[]) => classes.filter(Boolean).join(' ');

--- a/src/routes/keyboard/+page.svelte
+++ b/src/routes/keyboard/+page.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+	import { draggable, droppable, type DragDropState } from '$lib/index.js';
+	import { flip } from 'svelte/animate';
+	import { fade } from 'svelte/transition';
+	import '$lib/styles/dnd.css';
+
+	interface Item {
+		id: string;
+		title: string;
+		description: string;
+	}
+
+	let items = $state<Item[]>([
+		{
+			id: '1',
+			title: 'design system updates',
+			description: 'Tab here, press Space to grab, arrows to move, Space to drop'
+		},
+		{
+			id: '2',
+			title: 'user research',
+			description: 'Escape cancels a keyboard drag'
+		},
+		{
+			id: '3',
+			title: 'api documentation',
+			description: 'Mouse and touch still work the same'
+		},
+		{
+			id: '4',
+			title: 'accessibility review',
+			description: 'Screen readers get assertive live announcements'
+		}
+	]);
+
+	function handleDrop(state: DragDropState<Item>) {
+		const { draggedItem, targetContainer, dropPosition } = state;
+		const dragIndex = items.findIndex((item) => item.id === draggedItem.id);
+		let dropIndex = parseInt(targetContainer ?? '0');
+		if (dropPosition === 'after') dropIndex += 1;
+
+		if (dragIndex !== -1 && !isNaN(dropIndex)) {
+			const next = [...items];
+			const [item] = next.splice(dragIndex, 1);
+			const adjusted = dragIndex < dropIndex ? dropIndex - 1 : dropIndex;
+			next.splice(adjusted, 0, item);
+			items = next;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Keyboard Accessibility - SvelteDnD Examples</title>
+	<meta
+		name="description"
+		content="Reorder a list with the keyboard using Space, arrow keys, and Escape. Opt-in keyboard accessibility for SvelteDnD."
+	/>
+	<meta property="og:title" content="Keyboard Accessibility - SvelteDnD" />
+	<meta
+		property="og:description"
+		content="Keyboard grab, move, and drop with screen reader announcements"
+	/>
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content="https://sveltednd.thisux.com/keyboard" />
+</svelte:head>
+
+<div class="min-h-screen pt-20 md:pt-0">
+	<header class="border-b border-swiss-black px-8 py-12 dark:border-white/20 md:px-16 md:py-16">
+		<h1 class="text-3xl text-swiss-black dark:text-white md:text-4xl">keyboard accessibility</h1>
+		<p class="mt-4 max-w-2xl text-sm text-swiss-mid-gray dark:text-white/60">
+			Opt-in with <code class="text-swiss-black dark:text-white">keyboard: true</code> on
+			<code class="text-swiss-black dark:text-white">draggable</code>. Same
+			<code class="text-swiss-black dark:text-white">onDrop</code> handler as mouse and touch.
+		</p>
+		<ul class="mt-6 max-w-xl space-y-1 text-xs text-swiss-mid-gray dark:text-white/50">
+			<li><strong class="text-swiss-black dark:text-white">Tab</strong> — focus an item</li>
+			<li>
+				<strong class="text-swiss-black dark:text-white">Space / Enter</strong> — pick up or drop
+			</li>
+			<li>
+				<strong class="text-swiss-black dark:text-white">↑ / ↓</strong> — move drop preview
+			</li>
+			<li><strong class="text-swiss-black dark:text-white">Escape</strong> — cancel</li>
+		</ul>
+	</header>
+
+	<div class="p-8 md:p-16">
+		<div class="max-w-2xl">
+			<div
+				class="border border-swiss-black dark:border-white/20"
+				role="list"
+				aria-label="Reorderable tasks"
+			>
+				{#each items as item, index (item.id)}
+					<div
+						role="listitem"
+						use:draggable={{
+							container: index.toString(),
+							dragData: item,
+							keyboard: true
+						}}
+						use:droppable={{
+							container: index.toString(),
+							callbacks: { onDrop: handleDrop }
+						}}
+						animate:flip={{ duration: 200 }}
+						in:fade={{ duration: 150 }}
+						out:fade={{ duration: 150 }}
+						class="svelte-dnd-touch-feedback cursor-move border-b border-swiss-black bg-white p-6 transition-all last:border-b-0 hover:bg-swiss-gray focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-swiss-red dark:border-white/20 dark:bg-swiss-black dark:hover:bg-white/10"
+					>
+						<div class="flex items-start gap-6">
+							<span class="text-xs text-swiss-mid-gray dark:text-white/60"
+								>{(index + 1).toString().padStart(2, '0')}</span
+							>
+							<div class="flex-1">
+								<h2 class="text-sm text-swiss-black dark:text-white">{item.title}</h2>
+								<p class="mt-1 text-xs text-swiss-mid-gray dark:text-white/60">
+									{item.description}
+								</p>
+							</div>
+						</div>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</div>
+</div>
+
+<style>
+	:global(.dragging) {
+		opacity: 0.5;
+		outline: 1px solid #0a0a0a;
+	}
+
+	:global(.drag-over) {
+		background-color: #f5f5f5;
+		outline: 1px dashed #a3a3a3;
+	}
+
+	:global(.dark .dragging) {
+		outline: 1px solid rgba(255, 255, 255, 0.5);
+	}
+
+	:global(.dark .drag-over) {
+		background-color: rgba(255, 255, 255, 0.1);
+		outline: 1px dashed rgba(255, 255, 255, 0.3);
+	}
+</style>

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -22,14 +22,18 @@ Studio: https://thisux.com
 - [Interactive Elements](/interactive-elements): Draggable items containing buttons, inputs, and links that remain fully interactive
 - [Conditional Check](/conditional-check): Accept or reject drops based on custom logic
 - [Custom Classes](/custom-classes): Override default drag/drop CSS classes with your own
+- [Attachments](/attach): `{@attach attachDraggable}` / `attachDroppable` on components
+- [Keyboard](/keyboard): Opt-in Space / arrows / Escape reordering with live announcements
 
 ## Core Exports
 
-The library exports exactly three things from `@thisux/sveltednd`:
+From `@thisux/sveltednd`:
 
 - `draggable` — Svelte action. Attach to any element to make it draggable.
 - `droppable` — Svelte action. Attach to any element to make it a drop target.
+- `attachDraggable` / `attachDroppable` — Attachment factories for `{@attach}` (Svelte 5.29+).
 - `dndState` — Global reactive state object. Tracks the active drag operation in real time.
+- `resetDndState` — Force-clear global drag state.
 
 ## draggable Action
 
@@ -55,6 +59,21 @@ All options from `DragDropOptions<T>` plus:
 | `callbacks` | `DragDropCallbacks<T>` | No | Lifecycle event handlers. |
 | `attributes` | `DragDropAttributes` | No | Custom CSS class overrides. |
 | `direction` | `'vertical' \| 'horizontal' \| 'grid'` | No | List layout. Defaults to `'vertical'`. Affects drop indicator direction and position detection. |
+| `keyboard` | `boolean \| KeyboardOptions` | No | Opt-in keyboard reordering (`true` enables Space/Enter grab & drop, arrows to move, Escape to cancel). Default off. |
+
+### Keyboard example
+
+```svelte
+<div
+  use:draggable={{ container: index.toString(), dragData: item, keyboard: true }}
+  use:droppable={{ container: index.toString(), callbacks: { onDrop: handleDrop } }}
+>
+  {item.title}
+</div>
+```
+
+Keys: Tab focus → Space/Enter pick up → arrows move preview → Space/Enter drop → Escape cancel.
+Uses the same `onDrop` contract as pointer/HTML5. Assertive live region announces status.
 
 ### Handle Example
 


### PR DESCRIPTION
## Summary

Implements **#24** keyboard accessibility as an **opt-in** third input path (alongside HTML5 + pointer), without breaking existing mouse/touch behavior.

### Usage

```svelte
use:draggable={{ container: index.toString(), dragData: item, keyboard: true }}
```

| Key | Action |
|-----|--------|
| Tab | Focus item (`tabindex=0` only when enabled) |
| Space / Enter | Grab or drop |
| ↑↓ (←→ horizontal) | Move drop preview among registered droppables |
| Escape | Cancel (no `onDrop`) |

### Architecture

- **Droppable registry** — mount/unmount registration; deepest-target preference (#27)
- **Keyboard session** — grab / move / drop / cancel; same `onDrop` + `finalizeDropSession` as pointer
- **Live region** — assertive announcements (grab/move/drop/cancel)
- **`dndState.dragInput`** — `'html5' | 'pointer' | 'keyboard' | null` (additive)
- Default **off** → zero tabindex/listener changes for existing apps

### Demo

- `/keyboard` — sortable list with keyboard enabled

### Follow-ups (not in this PR)

- Cross-container Kanban navigation (`navigation: 'containers'`)
- Roving tabindex; default-on only in 1.0 if desired

## Test plan

- [x] `bun run test` — 108 tests pass
- [x] `bun run check` / lint / package
- [ ] Manual: `/keyboard` — Tab → Space → arrows → Space; Escape cancel
- [ ] Manual: mouse/touch on other demos still work with no `keyboard` option
- [ ] Optional: VoiceOver/NVDA announcements

Closes #24